### PR TITLE
[SeoBundle] routing event listener only trigger on default context

### DIFF
--- a/bundles/SeoBundle/src/EventListener/RoutingListener.php
+++ b/bundles/SeoBundle/src/EventListener/RoutingListener.php
@@ -56,7 +56,7 @@ class RoutingListener implements EventSubscriberInterface
         if (!$this->matchesOpenDxpContext($request, OpenDxpContextResolver::CONTEXT_DEFAULT)) {
             return;
         }
-        
+
         $response = $this->redirectHandler->checkForRedirect($request, true);
         if ($response) {
             $event->setResponse($response);

--- a/bundles/SeoBundle/src/EventListener/RoutingListener.php
+++ b/bundles/SeoBundle/src/EventListener/RoutingListener.php
@@ -20,6 +20,7 @@ namespace OpenDxp\Bundle\SeoBundle\EventListener;
 use OpenDxp\Bundle\CoreBundle\EventListener\Traits\OpenDxpContextAwareTrait;
 use OpenDxp\Bundle\SeoBundle\OpenDxpSeoBundle;
 use OpenDxp\Bundle\SeoBundle\Redirect\RedirectHandler;
+use OpenDxp\Http\Request\Resolver\OpenDxpContextResolver;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -52,6 +53,10 @@ class RoutingListener implements EventSubscriberInterface
         }
 
         $request = $event->getRequest();
+        if (!$this->matchesOpenDxpContext($request, OpenDxpContextResolver::CONTEXT_DEFAULT)) {
+            return;
+        }
+        
         $response = $this->redirectHandler->checkForRedirect($request, true);
         if ($response) {
             $event->setResponse($response);
@@ -64,10 +69,15 @@ class RoutingListener implements EventSubscriberInterface
             return;
         }
 
+        $request = $event->getRequest();
+        if (!$this->matchesOpenDxpContext($request, OpenDxpContextResolver::CONTEXT_DEFAULT)) {
+            return;
+        }
+
         // in case routing didn't find a matching route, check for redirects without override
         $exception = $event->getThrowable();
         if ($exception instanceof NotFoundHttpException) {
-            $response = $this->redirectHandler->checkForRedirect($event->getRequest(), false);
+            $response = $this->redirectHandler->checkForRedirect($request, false);
             if ($response) {
                 $event->setResponse($response);
             }


### PR DESCRIPTION
## Improvement description

Redirect resolving can be expensive.
To improve performance for opendxp admin interface and/or remove interferences with other applications built on top of OpenDxp with a different context, the Routing Listener of OpenDxp's SeoBundle should only trigger for the OpenDxp context `default`.