### PR TITLE
Make `open-dxp/admin-bundle` a core-dependency

### DIFF
--- a/.github/workflows/codeception.yaml
+++ b/.github/workflows/codeception.yaml
@@ -109,6 +109,8 @@ jobs:
 
             - name: "Install dependencies with Composer"
               uses: "ramsey/composer-install@v2"
+              env:
+                  COMPOSER_ROOT_VERSION: "1.1.x-dev"
               with:
                   dependency-versions: "${{ matrix.dependencies }}"
                   composer-options: "${{ matrix.composer-options }}"

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -67,6 +67,8 @@ jobs:
 
             - name: "Install dependencies with Composer"
               uses: "ramsey/composer-install@v2"
+              env:
+                  COMPOSER_ROOT_VERSION: "1.1.x-dev"
               with:
                   dependency-versions: "${{ matrix.dependencies }}"
                   composer-options: "${{ matrix.composer-options }}"

--- a/bundles/CoreBundle/src/OpenDxpCoreBundle.php
+++ b/bundles/CoreBundle/src/OpenDxpCoreBundle.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace OpenDxp\Bundle\CoreBundle;
 
+use OpenDxp\Bundle\AdminBundle\OpenDxpAdminBundle;
 use OpenDxp\Bundle\CoreBundle\DependencyInjection\Compiler\AreabrickPass;
 use OpenDxp\Bundle\CoreBundle\DependencyInjection\Compiler\CacheFallbackPass;
 use OpenDxp\Bundle\CoreBundle\DependencyInjection\Compiler\HtmlSanitizerPass;
@@ -34,6 +35,8 @@ use OpenDxp\Bundle\CoreBundle\DependencyInjection\Compiler\ServiceControllersPas
 use OpenDxp\Bundle\CoreBundle\DependencyInjection\Compiler\TranslationSanitizerPass;
 use OpenDxp\Bundle\CoreBundle\DependencyInjection\Compiler\WorkflowPass;
 use OpenDxp\Bundle\CoreBundle\DependencyInjection\OpenDxpCoreExtension;
+use OpenDxp\HttpKernel\Bundle\DependentBundleInterface;
+use OpenDxp\HttpKernel\BundleCollection\BundleCollection;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -41,7 +44,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 /**
  * @internal
  */
-class OpenDxpCoreBundle extends Bundle
+class OpenDxpCoreBundle extends Bundle implements DependentBundleInterface
 {
     public function getContainerExtension(): ExtensionInterface
     {
@@ -76,5 +79,10 @@ class OpenDxpCoreBundle extends Bundle
     public function getPath(): string
     {
         return dirname(__DIR__);
+    }
+
+    public static function registerDependentBundles(BundleCollection $collection): void
+    {
+        $collection->addBundle(new OpenDxpAdminBundle(), 60);
     }
 }

--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -24,6 +24,7 @@ use Doctrine\DBAL\DriverManager;
 use Exception;
 use InvalidArgumentException;
 use OpenDxp;
+use OpenDxp\Bundle\AdminBundle\OpenDxpAdminBundle;
 use OpenDxp\Bundle\ApplicationLoggerBundle\OpenDxpApplicationLoggerBundle;
 use OpenDxp\Bundle\CustomReportsBundle\OpenDxpCustomReportsBundle;
 use OpenDxp\Bundle\GenericExecutionEngineBundle\OpenDxpGenericExecutionEngineBundle;
@@ -68,6 +69,7 @@ class Installer
     const RECOMMENDED_BUNDLES = ['OpenDxpSimpleBackendSearchBundle'];
 
     public const INSTALLABLE_BUNDLES = [
+        'OpenDxpAdminBundle' => OpenDxpAdminBundle::class,
         'OpenDxpApplicationLoggerBundle' => OpenDxpApplicationLoggerBundle::class,
         'OpenDxpCustomReportsBundle' => OpenDxpCustomReportsBundle::class,
         'OpenDxpGlossaryBundle' => OpenDxpGlossaryBundle::class,

--- a/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
+++ b/bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
@@ -339,9 +339,7 @@ class SearchController extends UserAwareController
                 if (class_exists(GridData\DataObject::class)) {
                     $data = match (true) {
                         $element instanceof DataObject\AbstractObject => GridData\DataObject::getData($element, $fields),
-                        // @phpstan-ignore-next-line checking dataObject once is enough
                         $element instanceof Document => GridData\Document::getData($element),
-                        // @phpstan-ignore-next-line otherwise have to do class_exists for each element type
                         $element instanceof Asset => GridData\Asset::getData($element),
                         default => null
                     };

--- a/composer.json
+++ b/composer.json
@@ -221,6 +221,11 @@
     "bin": [
         "bin/opendxp-install"
     ],
+    "extra": {
+        "branch-alias": {
+            "dev-1.x": "1.1.x-dev"
+        }
+    },
     "config": {
         "sort-packages": true,
         "preferred-install": {

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
         "neitanod/forceutf8": "^2.0.4",
         "nesbot/carbon": "^3.8.4",
         "onnov/detect-encoding": "^2.0",
+        "open-dxp/admin-bundle": "*",
         "pear/net_url2": "^2.2",
         "presta/sitemap-bundle": "^3.3 || ^4.1",
         "sabre/dav": "^4.1.2",

--- a/composer.json
+++ b/composer.json
@@ -226,6 +226,9 @@
             "dev-1.x": "1.1.x-dev"
         }
     },
+    "replace": {
+      "open-dxp/opendxp": "self.version"
+    },
     "config": {
         "sort-packages": true,
         "preferred-install": {

--- a/composer.json
+++ b/composer.json
@@ -226,9 +226,6 @@
             "dev-1.x": "1.1.x-dev"
         }
     },
-    "replace": {
-      "open-dxp/opendxp": "self.version"
-    },
     "config": {
         "sort-packages": true,
         "preferred-install": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,11 +31,6 @@ parameters:
 			path: bundles/CustomReportsBundle/src/DependencyInjection/Configuration.php
 
 		-
-			message: "#^Call to method addSetting\\(\\) on an unknown class OpenDxp\\\\Bundle\\\\AdminBundle\\\\Event\\\\IndexActionSettingsEvent\\.$#"
-			count: 1
-			path: bundles/CustomReportsBundle/src/EventListener/IndexSettingsListener.php
-
-		-
 			message: "#^File is missing a \"declare\\(strict_types\\=1\\)\" declaration\\.$#"
 			count: 1
 			path: bundles/CustomReportsBundle/src/EventListener/IndexSettingsListener.php
@@ -111,26 +106,6 @@ parameters:
 			path: bundles/SeoBundle/src/Model/Redirect/Listing/Dao.php
 
 		-
-			message: "#^Access to constant CONTEXT_SEARCH on an unknown class OpenDxp\\\\Bundle\\\\AdminBundle\\\\Event\\\\ElementAdminStyleEvent\\.$#"
-			count: 1
-			path: bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
-
-		-
-			message: "#^Access to constant RESOLVE_ELEMENT_ADMIN_STYLE on an unknown class OpenDxp\\\\Bundle\\\\AdminBundle\\\\Event\\\\AdminEvents\\.$#"
-			count: 1
-			path: bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
-
-		-
-			message: "#^Call to method getAdminStyle\\(\\) on an unknown class OpenDxp\\\\Bundle\\\\AdminBundle\\\\Event\\\\ElementAdminStyleEvent\\.$#"
-			count: 1
-			path: bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
-
-		-
-			message: "#^Call to method getFilterCondition\\(\\) on an unknown class OpenDxp\\\\Bundle\\\\AdminBundle\\\\Helper\\\\GridHelperService\\.$#"
-			count: 2
-			path: bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
-
-		-
 			message: "#^Instantiated class OpenDxp\\\\Bundle\\\\AdminBundle\\\\Event\\\\ElementAdminStyleEvent not found\\.$#"
 			count: 1
 			path: bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
@@ -154,11 +129,6 @@ parameters:
 			message: "#^File is missing a \"declare\\(strict_types\\=1\\)\" declaration\\.$#"
 			count: 1
 			path: bundles/StaticRoutesBundle/src/DependencyInjection/Configuration.php
-
-		-
-			message: "#^Call to method addSetting\\(\\) on an unknown class OpenDxp\\\\Bundle\\\\AdminBundle\\\\Event\\\\IndexActionSettingsEvent\\.$#"
-			count: 1
-			path: bundles/StaticRoutesBundle/src/EventListener/IndexSettingsListener.php
 
 		-
 			message: "#^File is missing a \"declare\\(strict_types\\=1\\)\" declaration\\.$#"
@@ -586,26 +556,6 @@ parameters:
 			path: models/DataObject/QuantityValue/Unit/Listing/Dao.php
 
 		-
-			message: "#^Call to method expandLocales\\(\\) on an unknown class OpenDxp\\\\Bundle\\\\AdminBundle\\\\DataObject\\\\GridColumnConfig\\\\ConfigElementInterface\\.$#"
-			count: 1
-			path: models/DataObject/Service.php
-
-		-
-			message: "#^Call to method getLabeledValue\\(\\) on an unknown class OpenDxp\\\\Bundle\\\\AdminBundle\\\\DataObject\\\\GridColumnConfig\\\\ConfigElementInterface\\.$#"
-			count: 1
-			path: models/DataObject/Service.php
-
-		-
-			message: "#^Call to method getRenderer\\(\\) on an unknown class OpenDxp\\\\Bundle\\\\AdminBundle\\\\DataObject\\\\GridColumnConfig\\\\ConfigElementInterface\\.$#"
-			count: 2
-			path: models/DataObject/Service.php
-
-		-
-			message: "#^Call to method getValidLanguages\\(\\) on an unknown class OpenDxp\\\\Bundle\\\\AdminBundle\\\\DataObject\\\\GridColumnConfig\\\\ConfigElementInterface\\.$#"
-			count: 1
-			path: models/DataObject/Service.php
-
-		-
 			message: "#^Class OpenDxp\\\\Bundle\\\\AdminBundle\\\\DataObject\\\\GridColumnConfig\\\\Service not found\\.$#"
 			count: 1
 			path: models/DataObject/Service.php
@@ -854,16 +804,6 @@ parameters:
 			message: "#^File is missing a \"declare\\(strict_types\\=1\\)\" declaration\\.$#"
 			count: 1
 			path: models/Translation/Listing/Dao.php
-
-		-
-			message: "#^Call to static method get\\(\\) on an unknown class OpenDxp\\\\Bundle\\\\AdminBundle\\\\Perspective\\\\Config\\.$#"
-			count: 1
-			path: models/User.php
-
-		-
-			message: "#^Call to static method getAvailablePerspectives\\(\\) on an unknown class OpenDxp\\\\Bundle\\\\AdminBundle\\\\Perspective\\\\Config\\.$#"
-			count: 1
-			path: models/User.php
 
 		-
 			message: "#^File is missing a \"declare\\(strict_types\\=1\\)\" declaration\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -76,11 +76,6 @@ parameters:
 			path: bundles/InstallBundle/src/Event/InstallEvents.php
 
 		-
-			message: "#^Call to an undefined method OpenDxp\\\\Bundle\\\\SeoBundle\\\\Controller\\\\Document\\\\DocumentController\\:\\:getTreeNodeConfig\\(\\)\\.$#"
-			count: 1
-			path: bundles/SeoBundle/src/Controller/Document/DocumentController.php
-
-		-
 			message: "#^File is missing a \"declare\\(strict_types\\=1\\)\" declaration\\.$#"
 			count: 1
 			path: bundles/SeoBundle/src/Controller/Document/DocumentController.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36,11 +36,6 @@ parameters:
 			path: bundles/CustomReportsBundle/src/EventListener/IndexSettingsListener.php
 
 		-
-			message: "#^Parameter \\$settingsEvent of method OpenDxp\\\\Bundle\\\\CustomReportsBundle\\\\EventListener\\\\IndexSettingsListener\\:\\:indexSettings\\(\\) has invalid type OpenDxp\\\\Bundle\\\\AdminBundle\\\\Event\\\\IndexActionSettingsEvent\\.$#"
-			count: 1
-			path: bundles/CustomReportsBundle/src/EventListener/IndexSettingsListener.php
-
-		-
 			message: "#^File is missing a \"declare\\(strict_types\\=1\\)\" declaration\\.$#"
 			count: 1
 			path: bundles/CustomReportsBundle/src/Tool/Config/Dao.php
@@ -106,16 +101,6 @@ parameters:
 			path: bundles/SeoBundle/src/Model/Redirect/Listing/Dao.php
 
 		-
-			message: "#^Instantiated class OpenDxp\\\\Bundle\\\\AdminBundle\\\\Event\\\\ElementAdminStyleEvent not found\\.$#"
-			count: 1
-			path: bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
-
-		-
-			message: "#^Parameter \\$gridHelperService of method OpenDxp\\\\Bundle\\\\SimpleBackendSearchBundle\\\\Controller\\\\SearchController\\:\\:findAction\\(\\) has invalid type OpenDxp\\\\Bundle\\\\AdminBundle\\\\Helper\\\\GridHelperService\\.$#"
-			count: 1
-			path: bundles/SimpleBackendSearchBundle/src/Controller/SearchController.php
-
-		-
 			message: "#^Method OpenDxp\\\\Bundle\\\\SimpleBackendSearchBundle\\\\MessageHandler\\\\SearchBackendHandler\\:\\:process\\(\\) is unused\\.$#"
 			count: 1
 			path: bundles/SimpleBackendSearchBundle/src/MessageHandler/SearchBackendHandler.php
@@ -132,11 +117,6 @@ parameters:
 
 		-
 			message: "#^File is missing a \"declare\\(strict_types\\=1\\)\" declaration\\.$#"
-			count: 1
-			path: bundles/StaticRoutesBundle/src/EventListener/IndexSettingsListener.php
-
-		-
-			message: "#^Parameter \\$settingsEvent of method OpenDxp\\\\Bundle\\\\StaticRoutesBundle\\\\EventListener\\\\IndexSettingsListener\\:\\:indexSettings\\(\\) has invalid type OpenDxp\\\\Bundle\\\\AdminBundle\\\\Event\\\\IndexActionSettingsEvent\\.$#"
 			count: 1
 			path: bundles/StaticRoutesBundle/src/EventListener/IndexSettingsListener.php
 
@@ -554,16 +534,6 @@ parameters:
 			message: "#^File is missing a \"declare\\(strict_types\\=1\\)\" declaration\\.$#"
 			count: 1
 			path: models/DataObject/QuantityValue/Unit/Listing/Dao.php
-
-		-
-			message: "#^Class OpenDxp\\\\Bundle\\\\AdminBundle\\\\DataObject\\\\GridColumnConfig\\\\Service not found\\.$#"
-			count: 1
-			path: models/DataObject/Service.php
-
-		-
-			message: "#^Method OpenDxp\\\\Model\\\\DataObject\\\\Service\\:\\:getConfigForHelperDefinition\\(\\) has invalid return type OpenDxp\\\\Bundle\\\\AdminBundle\\\\DataObject\\\\GridColumnConfig\\\\ConfigElementInterface\\.$#"
-			count: 1
-			path: models/DataObject/Service.php
 
 		-
 			message: "#^File is missing a \"declare\\(strict_types\\=1\\)\" declaration\\.$#"

--- a/tests/Model/Permissions/ModelAssetPermissionsTest.php
+++ b/tests/Model/Permissions/ModelAssetPermissionsTest.php
@@ -453,6 +453,7 @@ class ModelAssetPermissionsTest extends ModelTestCase
             new EventDispatcher(),
             $this
                 ->getMockBuilder('\OpenDxp\Bundle\AdminBundle\Helper\GridHelperService')
+                ->disableOriginalConstructor()
                 ->getMock() //this is not used in the test
         );
 

--- a/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
+++ b/tests/Model/Permissions/ModelDataObjectPermissionsTest.php
@@ -591,6 +591,7 @@ class ModelDataObjectPermissionsTest extends ModelTestCase
             new EventDispatcher(),
             $this
                 ->getMockBuilder('\OpenDxp\Bundle\AdminBundle\Helper\GridHelperService')
+                ->disableOriginalConstructor()
                 ->getMock() //this is not used in the test
         );
 

--- a/tests/Model/Permissions/ModelDocumentPermissionsTest.php
+++ b/tests/Model/Permissions/ModelDocumentPermissionsTest.php
@@ -443,6 +443,7 @@ class ModelDocumentPermissionsTest extends ModelTestCase
             new EventDispatcher(),
             $this
                 ->getMockBuilder('\OpenDxp\Bundle\AdminBundle\Helper\GridHelperService')
+                ->disableOriginalConstructor()
                 ->getMock() //this is not used in the test
         );
 


### PR DESCRIPTION
## Changes in this pull request  
Related to #10 

## Additional info
We want to refactor the `open-dxp/admin-ui-classic-bundle` to match the structure of the other "core" bundles (naming) and bring it back as a core dependency as this is currently the only UI for the backend.