### PR TITLE
Fix Docker image name in installation instructions

### DIFF
--- a/doc/01_Getting_Started/00_Installation/00_Docker_Based_Installation.md
+++ b/doc/01_Getting_Started/00_Installation/00_Docker_Based_Installation.md
@@ -15,7 +15,7 @@ You don't need to have a PHP environment with composer installed.
 
 ```bash 
 # empty skeleton package for experienced developers (`open-dxp/skeleton`).
-docker run -u `id -u`:`id -g` --rm -v `pwd`:/var/www/html open-dxp/opendxp:php8.3-latest composer create-project open-dxp/skeleton my-project
+docker run -u `id -u`:`id -g` --rm -v `pwd`:/var/www/html opendxp/opendxp:php8.3-latest composer create-project open-dxp/skeleton my-project
 ```
 
 2. Go to your new project


### PR DESCRIPTION
There is no dash in the package name at Dockerhub

<!--

Before submitting a contribution, please make sure you’re working on the correct branch:

- Bug fixes → target the latest maintenance branch (`1.0`)
- Features or improvements → target the main development branch (`1.x`)

> Note: All bug fixes merged into maintenance branches are regularly synced into the `1.x` dev branch.

## Your pull request must meet all of the following requirements:

- [ ] I have read and accepted the [CLA guidelines](/CLA.md).
- [ ] Features are properly documented in the `doc/` folder.
- [ ] Bug fixes include a short guide on how to reproduce the issue.
      → The target branch must be the oldest actively supported version (e.g. `1.0`; see `README.md` for details).
- [ ] Code follows project standards and passes all checks (e.g. PhpStan).

**Pull requests that don't follow these rules may be closed without comment.**

-->

## Changes in this pull request  
Resolves #

## Additional info