### PR TITLE
Add `symfony/var-exporter` dependency in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,6 +115,7 @@
         "symfony/uid": "^7.3",
         "symfony/validator": "^7.3",
         "symfony/var-dumper": "^7.3",
+        "symfony/var-exporter": "^7.3",
         "symfony/web-profiler-bundle": "^7.3",
         "symfony/webpack-encore-bundle": "^1.17 || ^2.0",
         "symfony/workflow": "^7.3",


### PR DESCRIPTION
## Changes in this pull request  
Contributes to #37 

## Additional info
Require installation of `symfony/var-exporter:^7.3`.