### PR TITLE
[Bugfix] Make translations sortable by dates

### DIFF
--- a/models/Translation/Listing.php
+++ b/models/Translation/Listing.php
@@ -53,7 +53,7 @@ class Listing extends Model\Listing\AbstractListing
     #[Override]
     public function isValidOrderKey(string $key): bool
     {
-        return in_array($key, ['key', 'type']) || in_array($key, $this->getLanguages());
+        return in_array($key, ['key', 'type', 'creationDate', 'modificationDate']) || in_array($key, $this->getLanguages());
     }
 
     public function getDomain(): string


### PR DESCRIPTION
There's a bug that website translation can only be sorted by key and type, but not creation and modification date, as the frontend suggests and as it was possible in the past.

By adding these columns to the valid order keys this is fixed.
