### PR TITLE
Snippets will be cached with wrong links in preview view

### DIFF
--- a/bundles/CoreBundle/src/EventListener/Frontend/FullPageCacheListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/FullPageCacheListener.php
@@ -130,6 +130,8 @@ class FullPageCacheListener
         }
 
         if (!\OpenDxp\Tool::useFrontendOutputFilters()) {
+            $this->disable('use frontend output filters');
+
             return;
         }
 


### PR DESCRIPTION
# Steps to reproduce
1. Create a document site (e. g. test-site)
2. Create a snippet with document links
3. Show the snippet with pimcore_inc() twig function
=> In Preview the url of the link is with the document site key (e. g. /test-site/about)
=> In Frontend the url of the link is without the document site key (e. g. /about)
4. Enable FullPageCache
5. Visit the preview first (Cache will be generated)
6. Logout
7. Show the frontend page
=> Snippet have the wrong link

# Fix
FullPageCache should be disabled in preview.
Twig function pimcore_inc and Editable Snippet will look to this with the Frontend::isOutputCacheEnabled() function.