### PR TITLE
Translator::checkForEmptyTranslation() - getValidLanguages needs to accept domain parameter

### DIFF
--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -253,7 +253,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
                         $t->setKey($id);
 
                         // add all available languages
-                        foreach (Translation::getValidLanguages() as $language) {
+                        foreach (Translation::getValidLanguages($domain) as $language) {
                             $t->addTranslation($language, '');
                         }
                     }


### PR DESCRIPTION
When using different languages for frontend and admin interface, the current Translator implementation does not respect the domain when creating the missing translation entries. So new admin translations will end up with the wrong locale (from frontend)  in the translations_admin table.