### PR TITLE
Add IgnoreCoreTablesFilterListener 

### DIFF
--- a/bundles/CoreBundle/config/event_listeners.yaml
+++ b/bundles/CoreBundle/config/event_listeners.yaml
@@ -4,7 +4,7 @@ services:
         autoconfigure: true
 
     #
-    # Request / ROuting
+    # Request / Routing
 
     OpenDxp\Bundle\CoreBundle\EventListener\Frontend\RoutingListener:
         calls:

--- a/bundles/CoreBundle/config/event_listeners.yaml
+++ b/bundles/CoreBundle/config/event_listeners.yaml
@@ -4,8 +4,7 @@ services:
         autoconfigure: true
 
     #
-    # REQUEST + ROUTING
-    #
+    # Request / ROuting
 
     OpenDxp\Bundle\CoreBundle\EventListener\Frontend\RoutingListener:
         calls:
@@ -22,8 +21,7 @@ services:
     OpenDxp\Bundle\CoreBundle\EventListener\OpenDxpHeaderListener: ~
 
     #
-    # TRANSLATIONS/LOCALE
-    #
+    # Translations / Locale
 
     OpenDxp\Bundle\CoreBundle\EventListener\Frontend\LocaleListener: ~
 
@@ -32,8 +30,7 @@ services:
     OpenDxp\Bundle\CoreBundle\EventListener\DumpTranslationEntriesListener: ~
 
     #
-    # OPENDXP OBJECTS/PARAMS LOGIC
-    #
+    # OpenDxp Objects/Params Logic
 
     OpenDxp\Bundle\CoreBundle\EventListener\Frontend\ElementListener:
         calls:
@@ -48,8 +45,7 @@ services:
             - { name: kernel.event_subscriber }
 
     #
-    # STATE HANDLING/INITIALIZING
-    #
+    # States
 
     # handles block state (current block, current index) for sub-requests
     OpenDxp\Bundle\CoreBundle\EventListener\Frontend\BlockStateListener:
@@ -61,16 +57,14 @@ services:
     OpenDxp\Bundle\CoreBundle\EventListener\Frontend\StaticPageGeneratorListener: ~
 
     #
-    # CONTROLLER HANDLING
-    #
+    # Controller
 
     OpenDxp\Bundle\CoreBundle\EventListener\Frontend\ContentTemplateListener: ~
 
     OpenDxp\Bundle\CoreBundle\EventListener\EventedControllerListener: ~
 
     #
-    # VARIOUS MODEL SPECIFIC LISTENERS
-    #
+    # Various Model specific Listeners
 
     OpenDxp\Bundle\CoreBundle\EventListener\WorkflowManagementListener:
         public: true # can be disabled
@@ -78,17 +72,14 @@ services:
     OpenDxp\Bundle\CoreBundle\EventListener\ElementTagsListener: ~
 
     #
-    # EXCEPTION HANDLING
-    #
+    # Exception Handling
 
     OpenDxp\Bundle\CoreBundle\EventListener\ResponseExceptionListener:
         calls:
             - [setLogger, ['@logger']]
 
-
     #
-    # RESPONSE TRANSFORMING
-    #
+    # Response Transforming
 
     OpenDxp\Bundle\CoreBundle\EventListener\ResponseHeaderListener: ~
 
@@ -100,10 +91,13 @@ services:
         arguments:
             $responseStack: '@OpenDxp\Http\ResponseStack'
 
+    #
+    # Doctrine Listeners
+
+    OpenDxp\Bundle\CoreBundle\EventListener\Doctrine\IgnoreCoreTablesFilterListener: ~
 
     #
-    # FRONTEND LISTENERS
-    #
+    # Frontend Listeners
 
     OpenDxp\Bundle\CoreBundle\EventListener\Frontend\InternalWysiwygHtmlAttributeFilterListener: ~
 

--- a/bundles/CoreBundle/config/services.yaml
+++ b/bundles/CoreBundle/config/services.yaml
@@ -4,8 +4,7 @@ services:
         autoconfigure: true
 
     #
-    # SECURITY
-    #
+    # Security
 
     # Only use with Symfony ver 5.3 or higher
     # Decorate the symfony encoder factory with our own. Encoders operating on opendxp admin users and opendxp objects using
@@ -21,7 +20,7 @@ services:
         arguments: ['@.inner', '@?']
 
     #
-    # INFRASTRUCTURE
+    # Infrastructure
 
     # creates needed opendxp directories
     OpenDxp\HttpKernel\CacheWarmer\MkdirCacheWarmer:
@@ -43,7 +42,7 @@ services:
             - { name: monolog.logger, channel: opendxp }
 
     #
-    # CONFIG
+    # Config
 
     OpenDxp\Config:
         public: true
@@ -51,9 +50,8 @@ services:
     OpenDxp\Config\ReportConfigWriter: ~
 
     #
-    # CONTROLLERS
+    # Controllers
 
-    # auto-register all controllers as services
     OpenDxp\Bundle\CoreBundle\Controller\:
         resource: '../src/Controller'
         public: true
@@ -173,7 +171,6 @@ services:
 
     OpenDxp\SystemSettingsConfig:
         public: true
-
 
     #
     # Notification Services

--- a/bundles/CoreBundle/config/services.yaml
+++ b/bundles/CoreBundle/config/services.yaml
@@ -22,7 +22,6 @@ services:
 
     #
     # INFRASTRUCTURE
-    #
 
     # creates needed opendxp directories
     OpenDxp\HttpKernel\CacheWarmer\MkdirCacheWarmer:
@@ -45,7 +44,7 @@ services:
 
     #
     # CONFIG
-    #
+
     OpenDxp\Config:
         public: true
 
@@ -53,7 +52,6 @@ services:
 
     #
     # CONTROLLERS
-    #
 
     # auto-register all controllers as services
     OpenDxp\Bundle\CoreBundle\Controller\:
@@ -68,7 +66,6 @@ services:
 
     #
     # HTTP/REST clients
-    #
 
     OpenDxp\Http\ClientFactory:
         # keep this public until static method was removed
@@ -152,9 +149,9 @@ services:
         alias: OpenDxp\Model\Version\Adapter\FileSystemVersionStorageAdapter
 
     OpenDxp\Model\Version\Adapter\FileSystemVersionStorageAdapter: ~
+
     #
-    # SECURITY
-    #
+    # Security
 
     # standard user provider returning admin users wrapped in a OpenDxp\Security\User\User proxy object.
     # using this user provider allows implementations to authenticate against opendxp users on every desired firewall
@@ -173,14 +170,13 @@ services:
 
     #
     # System Settings Services
-    #
+
     OpenDxp\SystemSettingsConfig:
         public: true
 
 
     #
     # Notification Services
-    #
 
     OpenDxp\Model\Notification\Service\NotificationService:
         public: true

--- a/bundles/CoreBundle/src/EventListener/Doctrine/IgnoreCoreTablesFilterListener.php
+++ b/bundles/CoreBundle/src/EventListener/Doctrine/IgnoreCoreTablesFilterListener.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace OpenDxp\Bundle\CoreBundle\EventListener\Doctrine;
+
+use Doctrine\DBAL\Schema\AbstractAsset;
+use Doctrine\Migrations\Tools\Console\Command\DoctrineCommand;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+#[AutoconfigureTag('doctrine.dbal.schema_filter')]
+class IgnoreCoreTablesFilterListener implements EventSubscriberInterface
+{
+    private bool $enabled = true;
+    protected bool $initialized = false;
+    protected array $coreTables;
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+
+    public function __invoke(AbstractAsset|string $assetName): bool
+    {
+        if (!$this->enabled) {
+            return true;
+        }
+
+        if ($assetName instanceof AbstractAsset) {
+            $assetName = $assetName->getName();
+        }
+
+        $this->loadManagedTables();
+
+        return in_array($assetName, $this->coreTables, true);
+    }
+
+    private function loadManagedTables(): void
+    {
+        if ($this->initialized === true) {
+            return;
+        }
+
+        $this->initialized = true;
+        $this->coreTables = [];
+
+        foreach ($this->managerRegistry->getManagers() as $em) {
+            foreach ($em->getMetadataFactory()->getAllMetadata() as $metadata) {
+                if ($metadata instanceof ClassMetadata && !in_array($metadata->getTableName(), $this->coreTables, true)) {
+                    $this->coreTables[] = $metadata->getTableName();
+                }
+            }
+        }
+    }
+
+    public function onConsoleCommand(ConsoleCommandEvent $event): void
+    {
+        if ($event->getCommand() instanceof DoctrineCommand) {
+            $this->enabled = false;
+        }
+    }
+
+    #[\Override]
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ConsoleEvents::COMMAND => 'onConsoleCommand',
+        ];
+    }
+}


### PR DESCRIPTION
This PR introduces a Doctrine DBAL schema filter (within `doctrine:schema:` commands) to filter out core tables which are not managed by doctrine.

To avoid interfering with Doctrine-related CLI tooling (notably migrations commands), the filter automatically disables itself when a Doctrine console command is detected.