### PR TITLE
Improve Generic Execution Engine Entities & Manager

### DIFF
--- a/bundles/GenericExecutionEngineBundle/config/opendxp/doctrine.yaml
+++ b/bundles/GenericExecutionEngineBundle/config/opendxp/doctrine.yaml
@@ -1,12 +1,9 @@
 doctrine:
     orm:
-        entity_managers:
-            opendxp:
-                connection: default
-                mappings:
-                    OpenDxpGenericExecutionEngineBundle:
-                        type: attribute
-                        is_bundle: true
-                        dir: "src/Entity"
-                        prefix: OpenDxp\Bundle\GenericExecutionEngineBundle\Entity
-                        alias: OpenDxpGenericExecutionEngineBundle
+        mappings:
+            OpenDxpGenericExecutionEngineBundle:
+                type: attribute
+                is_bundle: true
+                dir: src/Entity
+                prefix: OpenDxp\Bundle\GenericExecutionEngineBundle\Entity
+                alias: OpenDxpGenericExecutionEngineBundle

--- a/bundles/GenericExecutionEngineBundle/config/services.yaml
+++ b/bundles/GenericExecutionEngineBundle/config/services.yaml
@@ -1,12 +1,7 @@
 services:
-    # default configuration for services in *this* file
     _defaults:
-        # automatically injects dependencies in your services
         autowire: true
-        # automatically registers your services as commands, event subscribers, etc.
         autoconfigure: true
-        # this means you cannot fetch services directly from the container via $container->get()
-        # if you need to do this, you can override this setting on individual services
         public: false
 
     _instanceof:
@@ -16,18 +11,18 @@ services:
             tags:
                 - { name: messenger.message_handler, bus: generic.execution.engine.bus }
 
-    # ---------------------
-    # INSTALLER
-    # ---------------------
+    #
+    # Installer
+
     OpenDxp\Bundle\GenericExecutionEngineBundle\Installer:
         public: true
         arguments:
             $bundle: "@=service('kernel').getBundle('OpenDxpGenericExecutionEngineBundle')"
 
 
-    # ---------------------
+    #
     # Job Execution Engine
-    # ---------------------
+
     OpenDxp\Bundle\GenericExecutionEngineBundle\Agent\JobExecutionAgentInterface:
         class: OpenDxp\Bundle\GenericExecutionEngineBundle\Agent\JobExecutionAgent
         arguments:
@@ -36,13 +31,9 @@ services:
 
     OpenDxp\Bundle\GenericExecutionEngineBundle\Repository\JobRunRepositoryInterface:
         class: OpenDxp\Bundle\GenericExecutionEngineBundle\Repository\JobRunRepository
-        arguments:
-            $openDxpEntityManager: "@doctrine.orm.opendxp_entity_manager"
 
     OpenDxp\Bundle\GenericExecutionEngineBundle\Repository\JobRunErrorLogRepositoryInterface:
         class: OpenDxp\Bundle\GenericExecutionEngineBundle\Repository\JobRunErrorLogRepository
-        arguments:
-            $openDxpEntityManager: "@doctrine.orm.opendxp_entity_manager"
 
     OpenDxp\Bundle\GenericExecutionEngineBundle\Grid\JobRunGridInterface:
         class: OpenDxp\Bundle\GenericExecutionEngineBundle\Grid\JobRunGrid
@@ -54,31 +45,29 @@ services:
 
     OpenDxp\Bundle\GenericExecutionEngineBundle\EventSubscriber\JobRunStatusChangeSubscriber:
         tags:
-            -
-                name: 'doctrine.event_listener'
-                event: 'preUpdate'
-                priority: 500
-                connection: 'default'
+            - { name: doctrine.event_listener, event: preUpdate,  priority: 500, connection: default }
+
+    OpenDxp\Bundle\GenericExecutionEngineBundle\EventSubscriber\PostGenerateJobSchemaSubscriber: ~
 
     OpenDxp\Bundle\GenericExecutionEngineBundle\Extractor\JobRunExtractorInterface:
         class: OpenDxp\Bundle\GenericExecutionEngineBundle\Extractor\JobRunExtractor
 
-    # ---------------------
+    #
     # Security Services
-    # ---------------------
+
     OpenDxp\Bundle\GenericExecutionEngineBundle\Security\PermissionServiceInterface:
         class: OpenDxp\Bundle\GenericExecutionEngineBundle\Security\PermissionService
 
-    # ---------------------
+    #
     # Configuration
-    # ---------------------
+
     OpenDxp\Bundle\GenericExecutionEngineBundle\Configuration\ExecutionContextInterface:
         class: OpenDxp\Bundle\GenericExecutionEngineBundle\Configuration\ExecutionContext
 
 
-    # ---------------------
+    #
     # Middleware
-    # ---------------------
+
 
     OpenDxp\Messenger\Middleware\CollectGarbageMiddleware:
         tags:

--- a/bundles/GenericExecutionEngineBundle/src/Entity/JobRun.php
+++ b/bundles/GenericExecutionEngineBundle/src/Entity/JobRun.php
@@ -40,53 +40,54 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[Table(name: 'generic_execution_engine_job_run')]
 class JobRun
 {
-    public const DEFAULT_EXECUTION_CONTEXT = 'default';
+    public const string DEFAULT_EXECUTION_CONTEXT = 'default';
 
-    #[ORM\Column]
+    #[ORM\Column(options: ['unsigned' => true])]
     #[ORM\GeneratedValue]
     #[ORM\Id]
     private int $id;
 
-    #[ORM\Column(type: 'string', length: 10, enumType: JobRunStates::class)]
+    #[ORM\Column(type: 'string', length: 100, enumType: JobRunStates::class)]
     private JobRunStates $state = JobRunStates::NOT_STARTED;
 
-    #[ORM\Column(type: 'integer', nullable: true)]
+    #[ORM\Column(type: 'integer', nullable: true, options: ['unsigned' => true])]
     private ?int $currentStep = null;
 
-    #[ORM\Column(length: 300, nullable: true)]
+    #[ORM\Column(type: 'text', length: 65535, nullable: true)]
     private ?string $currentMessage = null;
 
-    #[ORM\Column(type: 'text', nullable: true)]
+    #[ORM\Column(type: 'text', length: 65535, nullable: true)]
     private ?string $log = null;
 
     private ?SerializerInterface $serializer = null;
 
     private ?Job $job = null;
 
-    #[ORM\Column(type: 'text')]
+    #[ORM\Column(type: 'text', length: 4294967295, nullable: true)]
     private ?string $serializedJob = null;
 
-    #[ORM\Column(type: 'json')]
+    #[ORM\Column(type: 'text', length: 4294967295, nullable: true)]
     private ?array $context = null;
 
-    #[ORM\Column(nullable: false)]
+    #[ORM\Column(nullable: true)]
     private int $creationDate;
 
-    #[ORM\Column(nullable: false)]
+    #[ORM\Column(type: 'integer', nullable: true)]
     private int $modificationDate;
 
-    #[ORM\Column(type: 'string', length: 255)]
+    #[ORM\Column(type: 'string', length: 255, nullable: true, options: ['default' => JobRun::DEFAULT_EXECUTION_CONTEXT])]
     private string $executionContext = self::DEFAULT_EXECUTION_CONTEXT;
 
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
     private int $totalElements = 0;
 
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
     private int $processedElementsForStep = 0;
 
-    public function __construct(#[ORM\Column(nullable: true)]
-        private ?int $ownerId = null)
-    {
+    public function __construct(
+        #[ORM\Column(nullable: true, options: ['unsigned' => true])]
+        private ?int $ownerId = null
+    ) {
         $this->creationDate = time();
         $this->modificationDate = time();
     }

--- a/bundles/GenericExecutionEngineBundle/src/Entity/JobRunErrorLog.php
+++ b/bundles/GenericExecutionEngineBundle/src/Entity/JobRunErrorLog.php
@@ -29,19 +29,19 @@ use Doctrine\ORM\Mapping\Table;
 #[Table(name: 'generic_execution_engine_error_log')]
 class JobRunErrorLog
 {
-    #[ORM\Column]
+    #[ORM\Column(options: ['unsigned' => true])]
     #[ORM\GeneratedValue]
     #[ORM\Id]
     private int $id;
 
     public function __construct(
-        #[ORM\Column(type: 'integer')]
+        #[ORM\Column(type: 'integer', nullable: false, options: ['unsigned' => true])]
         private int $jobRunId,
-        #[ORM\Column(type: 'integer')]
+        #[ORM\Column(type: 'integer', nullable: false, options: ['unsigned' => true])]
         private int $stepNumber,
-        #[ORM\Column(type: 'integer', nullable: true)]
+        #[ORM\Column(type: 'integer', nullable: true, options: ['unsigned' => true])]
         private ?int $elementId = null,
-        #[ORM\Column(type: 'text', nullable: true)]
+        #[ORM\Column(type: 'text', length: 65535, nullable: true)]
         private ?string $errorMessage = null
     ) {
     }

--- a/bundles/GenericExecutionEngineBundle/src/EventSubscriber/PostGenerateJobSchemaSubscriber.php
+++ b/bundles/GenericExecutionEngineBundle/src/EventSubscriber/PostGenerateJobSchemaSubscriber.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace OpenDxp\Bundle\GenericExecutionEngineBundle\EventSubscriber;
+
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\DBAL\Schema\SchemaException;
+use Doctrine\ORM\Tools\Event\GenerateSchemaTableEventArgs;
+use Doctrine\ORM\Tools\ToolEvents;
+use OpenDxp\Bundle\GenericExecutionEngineBundle\Entity\JobRun;
+use OpenDxp\Bundle\GenericExecutionEngineBundle\Entity\JobRunErrorLog;
+use OpenDxp\Bundle\GenericExecutionEngineBundle\Utils\Constants\TableConstants;
+
+#[AsDoctrineListener(event: ToolEvents::postGenerateSchemaTable, connection: 'default')]
+final readonly class PostGenerateJobSchemaSubscriber
+{
+    /**
+     * @throws SchemaException
+     */
+    public function __invoke(GenerateSchemaTableEventArgs $eventArgs): void
+    {
+        $classMetadata = $eventArgs->getClassMetadata();
+        $table = $eventArgs->getClassTable();
+
+        if ($classMetadata->getName() === JobRun::class) {
+            $table->addForeignKeyConstraint(
+                'users',
+                ['ownerId'],
+                ['id'],
+                ['onDelete' => 'SET NULL'],
+                'fk_generic_job_execution_owner_users'
+            );
+        } elseif ($classMetadata->getName() === JobRunErrorLog::class) {
+            $table->addForeignKeyConstraint(
+                TableConstants::JOB_RUN_TABLE,
+                ['jobRunId'],
+                ['id'],
+                ['onDelete' => 'CASCADE'],
+                'fk_generic_job_execution_log_jobs'
+            );
+        }
+    }
+}


### PR DESCRIPTION
### General
This PR adjusts the `OpenDxpGenericExecutionEngineBundle` Entities to be 100% aligned with the installation script.

### Entity Manager
This PR also removes the absolutely unnecessary `@doctrine.orm.opendxp_entity_manager` Service and properly reconfigures the schema mapping for `OpenDxpGenericExecutionEngineBundle`. With this change, it is no longer necessary to define a `default_entity_manager` within the app. Is it okay to merge this into 1.2.1?

### Schema
Together with the already merged https://github.com/open-dxp/opendxp/pull/72, it is finally possible to update Doctrine schemas without any issues.

<img width="997" height="120" alt="image" src="https://github.com/user-attachments/assets/0f523b71-8fe7-4d32-9b5f-6fb3c977ee86" />
