### PR TITLE
Replace deprecated Doctrine DBAL query introspection methods

### DIFF
--- a/doc/20_Extending_OpenDxp/17_Custom_Persistent_Models.md
+++ b/doc/20_Extending_OpenDxp/17_Custom_Persistent_Models.md
@@ -422,8 +422,6 @@ class Dao extends Listing\Dao\AbstractDao
     }
 
     /**
-     * Get Count.
-     *
      * @throws \Exception
      */
     public function getCount(): int
@@ -438,18 +436,13 @@ class Dao extends Listing\Dao\AbstractDao
     }
 
     /**
-     * Get Total Count.
-     *
      * @throws \Exception
      */
     public function getTotalCount(): int
     {
         $queryBuilder = $this->getQueryBuilder();
-        $this->prepareQueryBuilderForTotalCount($queryBuilder, $this->getTableName() . '.id');
 
-        $totalCount = $this->db->fetchOne($queryBuilder->getSql(), $queryBuilder->getParameters(), $queryBuilder->getParameterTypes());
-
-        return (int) $totalCount;
+        return $this->getTotalCountFromQueryBuilder($queryBuilder, $this->getTableName() . '.id');
     }
 }
 ```

--- a/lib/Model/Listing/Dao/QueryBuilderHelperTrait.php
+++ b/lib/Model/Listing/Dao/QueryBuilderHelperTrait.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace OpenDxp\Model\Listing\Dao;
 
 use Doctrine\DBAL\Query\QueryBuilder;
-use Exception;
 use OpenDxp\Model\DataObject;
 
 trait QueryBuilderHelperTrait
@@ -126,8 +125,38 @@ trait QueryBuilderHelperTrait
         $queryBuilder->setMaxResults($this->model->getLimit());
     }
 
+    protected function getTotalCountFromQueryBuilder(QueryBuilder $queryBuilder, string $identifierColumn): int
+    {
+        $queryBuilder->select($identifierColumn);
+        $queryBuilder->resetOrderBy();
+        $queryBuilder->setMaxResults(null);
+        $queryBuilder->setFirstResult(0);
+
+        if (method_exists($this->model, 'addDistinct') && $this->model->addDistinct()) {
+            $queryBuilder->distinct();
+        }
+
+        $countSql = 'SELECT COUNT(*) FROM (' . $queryBuilder->getSQL() . ') count_subquery';
+
+        return (int) $this->db->fetchOne(
+            $countSql,
+            $queryBuilder->getParameters(),
+            $queryBuilder->getParameterTypes()
+        );
+    }
+
+    /**
+     * @deprecated Use getTotalCountFromQueryBuilder() instead. Will be removed in OpenDXP 2.0.
+     */
     protected function prepareQueryBuilderForTotalCount(QueryBuilder $queryBuilder, string $identifierColumn): void
     {
+        trigger_deprecation(
+            'opendxp/opendxp',
+            '1.2',
+            'Method "%s::prepareQueryBuilderForTotalCount()" is deprecated, use "getTotalCountFromQueryBuilder()" instead.',
+            static::class,
+        );
+
         $originalSelect = $queryBuilder->getQueryPart('select');
         $queryBuilder->select('COUNT(*)');
         $queryBuilder->resetOrderBy();
@@ -141,7 +170,6 @@ trait QueryBuilderHelperTrait
         if ($this->isQueryBuilderPartInUse($queryBuilder, 'groupBy') || $this->isQueryBuilderPartInUse($queryBuilder, 'having')) {
             $queryBuilder->select(empty($originalSelect) ? $identifierColumn : $originalSelect);
 
-            // Rewrite to 'SELECT COUNT(*) FROM (' . $queryBuilder . ') XYZ'
             $innerQuery = (string)$queryBuilder;
             $queryBuilder
                 ->resetQueryParts()
@@ -154,14 +182,16 @@ trait QueryBuilderHelperTrait
         }
     }
 
+    /**
+     * @deprecated Will be removed in OpenDXP 2.0.
+     */
     protected function isQueryBuilderPartInUse(QueryBuilder $query, string $part): bool
     {
         try {
             if ($query->getQueryPart($part)) {
                 return true;
             }
-        } catch (Exception) {
-            // do nothing
+        } catch (\Exception) {
         }
 
         return false;

--- a/models/Asset/Listing/Dao.php
+++ b/models/Asset/Listing/Dao.php
@@ -92,8 +92,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         $queryBuilder = $this->getQueryBuilder();
-        $this->prepareQueryBuilderForTotalCount($queryBuilder, 'assets.id');
 
-        return (int) $this->db->fetchOne($queryBuilder->getSql(), $queryBuilder->getParameters(), $queryBuilder->getParameterTypes());
+        return $this->getTotalCountFromQueryBuilder($queryBuilder, 'assets.id');
     }
 }

--- a/models/DataObject/Listing/Dao.php
+++ b/models/DataObject/Listing/Dao.php
@@ -76,11 +76,8 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         $queryBuilder = $this->getQueryBuilder();
-        $this->prepareQueryBuilderForTotalCount($queryBuilder, $this->getTableName() . '.id');
 
-        $totalCount = $this->db->fetchOne($queryBuilder->getSql(), $queryBuilder->getParameters(), $queryBuilder->getParameterTypes());
-
-        return (int) $totalCount;
+        return $this->getTotalCountFromQueryBuilder($queryBuilder, $this->getTableName() . '.id');
     }
 
     public function getCount(): int

--- a/models/Document/Listing/Dao.php
+++ b/models/Document/Listing/Dao.php
@@ -105,8 +105,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         $queryBuilder = $this->getQueryBuilder();
-        $this->prepareQueryBuilderForTotalCount($queryBuilder, 'documents.id');
 
-        return (int) $this->db->fetchOne($queryBuilder->getSql(), $queryBuilder->getParameters(), $queryBuilder->getParameterTypes());
+        return $this->getTotalCountFromQueryBuilder($queryBuilder, 'documents.id');
     }
 }

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -875,42 +875,49 @@ class Service extends Model\AbstractModel
     /**
      * Changes the query according to the custom view config
      *
-     *
      * @internal
      */
     public static function addTreeFilterJoins(array $cv, Asset\Listing|DataObject\Listing|Document\Listing $childrenList): void
     {
-        if ($cv) {
-            $childrenList->onCreateQueryBuilder(static function (DoctrineQueryBuilder $select) use ($cv): void {
-                $where = $cv['where'] ?? null;
-                if ($where) {
-                    $select->andWhere($where);
-                }
-
-                $fromAlias = $select->getQueryPart('from')[0]['alias'] ?? $select->getQueryPart('from')[0]['table'] ;
-
-                $customViewJoins = $cv['joins'] ?? null;
-                if ($customViewJoins) {
-                    foreach ($customViewJoins as $joinConfig) {
-                        $type = $joinConfig['type'];
-                        $method = $type == 'left' || $type == 'right' ? $type . 'Join' : 'join';
-
-                        $joinAlias = array_keys($joinConfig['name']);
-                        $joinAlias = reset($joinAlias);
-                        $joinTable = $joinConfig['name'][$joinAlias];
-
-                        $condition = $joinConfig['condition'];
-                        $columns = $joinConfig['columns'];
-                        $select->add('select', $columns, true);
-                        $select->$method($fromAlias, $joinTable, $joinAlias, $condition);
-                    }
-                }
-
-                if (!empty($cv['having'])) {
-                    $select->having($cv['having']);
-                }
-            });
+        if (count($cv) === 0) {
+            return;
         }
+
+        $fromAlias = match (true) {
+            $childrenList instanceof Asset\Listing => 'assets',
+            $childrenList instanceof Document\Listing => 'documents',
+            $childrenList instanceof DataObject\Listing => 'objects',
+            default => null,
+        };
+
+        $childrenList->onCreateQueryBuilder(static function (DoctrineQueryBuilder $select) use ($cv, $fromAlias): void {
+            $where = $cv['where'] ?? null;
+            if ($where) {
+                $select->andWhere($where);
+            }
+
+            $customViewJoins = $cv['joins'] ?? null;
+            if ($customViewJoins) {
+                foreach ($customViewJoins as $joinConfig) {
+                    $type = $joinConfig['type'];
+                    $method = $type === 'left' || $type === 'right' ? $type . 'Join' : 'join';
+
+                    $joinAlias = array_keys($joinConfig['name']);
+                    $joinAlias = reset($joinAlias);
+                    $joinTable = $joinConfig['name'][$joinAlias];
+
+                    $condition = $joinConfig['condition'];
+                    $columns = $joinConfig['columns'];
+                    $select->addSelect($columns);
+                    $select->$method($fromAlias, $joinTable, $joinAlias, $condition);
+                }
+            }
+
+            if (!empty($cv['having'])) {
+                $select->having($cv['having']);
+            }
+        });
+
     }
 
     public static function getValidKey(string $key, string $type): string

--- a/models/Element/Service.php
+++ b/models/Element/Service.php
@@ -887,7 +887,6 @@ class Service extends Model\AbstractModel
             $childrenList instanceof Asset\Listing => 'assets',
             $childrenList instanceof Document\Listing => 'documents',
             $childrenList instanceof DataObject\Listing => 'objects',
-            default => null,
         };
 
         $childrenList->onCreateQueryBuilder(static function (DoctrineQueryBuilder $select) use ($cv, $fromAlias): void {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -639,7 +639,7 @@ parameters:
 		-
 			message: '#^Call to function method_exists\(\) with OpenDxp\\Model\\DataObject\\Listing and ''addDistinct'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
-			count: 1
+			count: 2
 			path: models/DataObject/Listing/Dao.php
 
 		-


### PR DESCRIPTION
                                                                                                                                                                                                                                                                                                                                                 
  - Replace deprecated `getQueryPart()`, `resetQueryParts()` and `add()` calls with non-deprecated alternatives                                                                                                                                                                                                                                                                                                             
  - Introduce `getTotalCountFromQueryBuilder()` in `QueryBuilderHelperTrait` using  a subquery approach (`SELECT COUNT(*) FROM (inner_query)`) that handles all  cases (simple, GROUP BY, HAVING, DISTINCT) without query introspection                                                                                                                                                                                                                                                                       
  - Keep `prepareQueryBuilderForTotalCount()` and `isQueryBuilderPartInUse()` as deprecated BC methods with `trigger_deprecation()` — will be removed in 2.0                                                                                                                                                                                                                                                                  
  - Replace `getQueryPart('from')` in `Element\Service::addTreeFilterJoins()` by deriving the table name from the listing type via `match`                                                                                                                                                                                                                                                                                    
  - Replace `$select->add('select', ...)` with `$select->addSelect()`                                                                                                                                                                                                                                                                            
  - Update documentation example in Custom Persistent Models                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                     