### PR TITLE
Update upgrade notes and handle migration cleanup in CoreBundle

### DIFF
--- a/bundles/CoreBundle/src/Migrations/Version20251217000100.php
+++ b/bundles/CoreBundle/src/Migrations/Version20251217000100.php
@@ -33,12 +33,18 @@ final class Version20251217000100 extends AbstractMigration
             return;
         }
 
-        $this->addSql('
-            ALTER TABLE `http_error_log`
-                DROP COLUMN `parametersPost`,
-                DROP COLUMN `cookies`,
-                DROP COLUMN `serverVars`
-        ');
+        $t = $schema->getTable('http_error_log');
+        if ($t->hasColumn('parametersPost')) {
+            $this->addSql('ALTER TABLE `http_error_log` DROP COLUMN `parametersPost`');
+        }
+
+        if ($t->hasColumn('cookies')) {
+            $this->addSql('ALTER TABLE `http_error_log` DROP COLUMN `cookies`');
+        }
+
+        if ($t->hasColumn('serverVars')) {
+            $this->addSql('ALTER TABLE `http_error_log` DROP COLUMN `serverVars`');
+        }
     }
 
     public function down(Schema $schema): void

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -72,6 +72,10 @@ Upgrade to the latest Pimcore `11.5.x` first!
 - `OpenDxp\Model\Element\ElementInterface::getById()` changed signature. Check your code for implementations.
 - `OpenDxp\Workflow\Manager::getWorkflowByName()` changed return type to `null|Symfony\Component\Workflow\WorkflowInterface`.
 
+##### ⚠️ Migrations
+- Removed all migrations from `Pimcore\Bundle\CoreBundle\Migrations` namespace.
+  - Delete corresponding entries from `migration_versions` table in your database.
+
 ### Wysiwyg
 The suggested Quill editor lacks the capabilities expected in a professional CMS.
 As a result, we’ve reintroduced the TinyMCE bundle. (TinyMCE has changed its open-source license to GPL, which is acceptable for our use.)


### PR DESCRIPTION
1. Improve additional migrations which come from upstream to prevent duplicate execution and/or failure while migrating up
2. Add note about migrations to upgrade guide