### PR TITLE
Update IgnoreCoreTablesFilterListener

### DIFF
--- a/bundles/CoreBundle/src/EventListener/Doctrine/IgnoreCoreTablesFilterListener.php
+++ b/bundles/CoreBundle/src/EventListener/Doctrine/IgnoreCoreTablesFilterListener.php
@@ -20,6 +20,7 @@ use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\Migrations\Tools\Console\Command\DoctrineCommand;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
+use OpenDxp\Bundle\CoreBundle\Command\Bundle\InstallCommand;
 use Override;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
@@ -75,6 +76,8 @@ class IgnoreCoreTablesFilterListener implements EventSubscriberInterface
     public function onConsoleCommand(ConsoleCommandEvent $event): void
     {
         if ($event->getCommand() instanceof DoctrineCommand) {
+            $this->enabled = false;
+        } elseif ($event->getCommand() instanceof InstallCommand) {
             $this->enabled = false;
         }
     }

--- a/lib/Extension/Bundle/Installer/SettingsStoreAwareInstaller.php
+++ b/lib/Extension/Bundle/Installer/SettingsStoreAwareInstaller.php
@@ -77,12 +77,13 @@ abstract class SettingsStoreAwareInstaller extends AbstractInstaller
             $migrations = $this->dependencyFactory->getMigrationRepository()->getMigrations();
             $executedMigrations = $metadataStorage->getExecutedMigrations();
 
+            $metadataStorage->ensureInitialized();
+
             foreach ($migrations->getItems() as $migration) {
                 $version = $migration->getVersion();
 
                 if (!$executedMigrations->hasMigration($version)) {
                     $migrationResult = new ExecutionResult($version, Direction::UP);
-                    $metadataStorage->ensureInitialized();
                     $metadataStorage->complete($migrationResult);
                 }
 
@@ -105,9 +106,10 @@ abstract class SettingsStoreAwareInstaller extends AbstractInstaller
             $this->tableMetadataStorage->setPrefix($this->bundle->getNamespace());
             $executedMigrations = $metadataStorage->getExecutedMigrations();
 
+            $metadataStorage->ensureInitialized();
+
             foreach ($executedMigrations->getItems() as $migration) {
                 $migrationResult = new ExecutionResult($migration->getVersion(), Direction::DOWN);
-                $metadataStorage->ensureInitialized();
                 $metadataStorage->complete($migrationResult);
             }
         }


### PR DESCRIPTION
This PR disables the table filter when `InstallCommand` has been triggered. 

### Background
If a bundle defines migrations to skip via `getLastMigrationVersionClassName()`, an exception can occur:

`Base table or view already exists: 1050 Table 'migration_versions' already exists`

### Additional improvements
The` SettingsStoreAwareInstaller` has been slightly optimized by ensuring that `ensureInitialized()` is only called once before skipped migrations are added.