### PR TITLE
Introduce `GeneralHostResolver` service for centralized domain resolution

### DIFF
--- a/bundles/CoreBundle/config/request_response.yaml
+++ b/bundles/CoreBundle/config/request_response.yaml
@@ -21,6 +21,17 @@ services:
         public: false
 
     #
+    # GENERAL HOST RESOLVER
+    #
+    # Resolves the installation-wide "general" host.
+    #
+
+    OpenDxp\Http\Request\Host\GeneralHostResolver:
+        arguments:
+            $configuredDomain: '%opendxp.general_domain%'
+            $providers: !tagged_iterator opendxp.general_host_provider
+
+    #
     # REQUEST RESOLVERS
     #
     # Read/write/normalize defined request attributes (e.g. document)

--- a/bundles/CoreBundle/config/request_response.yaml
+++ b/bundles/CoreBundle/config/request_response.yaml
@@ -28,7 +28,6 @@ services:
 
     OpenDxp\Http\Request\Host\GeneralHostResolver:
         arguments:
-            $configuredDomain: '%opendxp.general_domain%'
             $providers: !tagged_iterator opendxp.general_host_provider
 
     #

--- a/bundles/CoreBundle/src/DependencyInjection/OpenDxpCoreExtension.php
+++ b/bundles/CoreBundle/src/DependencyInjection/OpenDxpCoreExtension.php
@@ -98,10 +98,6 @@ final class OpenDxpCoreExtension extends ConfigurableExtension implements Prepen
             $container->setParameter('router.request_context.host', $config['general']['domain']);
         }
 
-        // expose the configured domain as a standalone parameter so GeneralHostResolver
-        // can use it as a fallback independent of router.request_context.host
-        $container->setParameter('opendxp.general_domain', $domain);
-
         $loader = new YamlFileLoader(
             $container,
             new FileLocator(__DIR__ . '/../../config')

--- a/bundles/CoreBundle/src/DependencyInjection/OpenDxpCoreExtension.php
+++ b/bundles/CoreBundle/src/DependencyInjection/OpenDxpCoreExtension.php
@@ -98,6 +98,10 @@ final class OpenDxpCoreExtension extends ConfigurableExtension implements Prepen
             $container->setParameter('router.request_context.host', $config['general']['domain']);
         }
 
+        // expose the configured domain as a standalone parameter so GeneralHostResolver
+        // can use it as a fallback independent of router.request_context.host
+        $container->setParameter('opendxp.general_domain', $domain);
+
         $loader = new YamlFileLoader(
             $container,
             new FileLocator(__DIR__ . '/../../config')

--- a/bundles/CoreBundle/src/EventListener/Frontend/RoutingListener.php
+++ b/bundles/CoreBundle/src/EventListener/Frontend/RoutingListener.php
@@ -18,6 +18,7 @@ namespace OpenDxp\Bundle\CoreBundle\EventListener\Frontend;
 
 use OpenDxp\Bundle\CoreBundle\EventListener\Traits\OpenDxpContextAwareTrait;
 use OpenDxp\Config;
+use OpenDxp\Http\Request\Host\GeneralHostResolver;
 use OpenDxp\Http\Request\Resolver\OpenDxpContextResolver;
 use OpenDxp\Http\Request\Resolver\SiteResolver;
 use OpenDxp\Http\RequestHelper;
@@ -46,7 +47,8 @@ class RoutingListener implements EventSubscriberInterface
     public function __construct(
         protected RequestHelper $requestHelper,
         protected SiteResolver $siteResolver,
-        protected Config $config
+        protected Config $config,
+        protected GeneralHostResolver $generalHostResolver,
     ) {
     }
 
@@ -90,8 +92,6 @@ class RoutingListener implements EventSubscriberInterface
 
         // redirect to the main domain if specified
         $this->handleMainDomainRedirect($event);
-        if ($event->hasResponse()) {
-        }
     }
 
     /**
@@ -177,14 +177,14 @@ class RoutingListener implements EventSubscriberInterface
 
     private function resolveConfigDomainRedirectHost(Request $request): ?string
     {
-        $hostRedirect = null;
-
         $systemConfig = SystemSettingsConfig::get();
-        $gc = $systemConfig['general'];
-        if (isset($gc['redirect_to_maindomain']) && $gc['redirect_to_maindomain'] === true && isset($gc['domain']) && $gc['domain'] !== $request->getHost()) {
-            return $gc['domain'];
+        if (isset($systemConfig['general']['redirect_to_maindomain']) && $systemConfig['general']['redirect_to_maindomain'] === true) {
+            $domain = $this->generalHostResolver->resolve(['source' => $request]);
+            if ($domain !== null && $domain !== $request->getHost()) {
+                return $domain;
+            }
         }
 
-        return $hostRedirect;
+        return null;
     }
 }

--- a/bundles/SeoBundle/src/Redirect/RedirectHandler.php
+++ b/bundles/SeoBundle/src/Redirect/RedirectHandler.php
@@ -21,7 +21,6 @@ use OpenDxp\Bundle\SeoBundle\Event\Model\RedirectEvent;
 use OpenDxp\Bundle\SeoBundle\Event\RedirectEvents;
 use OpenDxp\Bundle\SeoBundle\Model\Redirect;
 use OpenDxp\Cache;
-use OpenDxp\Config;
 use OpenDxp\Event\Traits\RecursionBlockingEventDispatchHelperTrait;
 use OpenDxp\Helper\StringHelper;
 use OpenDxp\Http\Request\Host\GeneralHostResolver;
@@ -56,7 +55,6 @@ final class RedirectHandler
     public function __construct(
         private RequestHelper $requestHelper,
         private SiteResolver $siteResolver,
-        private Config $config,
         LockFactory $lockFactory,
         private LoggerInterface $logger,
         private LoggerInterface $redirectLogger,

--- a/bundles/SeoBundle/src/Redirect/RedirectHandler.php
+++ b/bundles/SeoBundle/src/Redirect/RedirectHandler.php
@@ -24,6 +24,7 @@ use OpenDxp\Cache;
 use OpenDxp\Config;
 use OpenDxp\Event\Traits\RecursionBlockingEventDispatchHelperTrait;
 use OpenDxp\Helper\StringHelper;
+use OpenDxp\Http\Request\Host\GeneralHostResolver;
 use OpenDxp\Http\Request\Resolver\SiteResolver;
 use OpenDxp\Http\RequestHelper;
 use OpenDxp\Model\Document;
@@ -58,7 +59,8 @@ final class RedirectHandler
         private Config $config,
         LockFactory $lockFactory,
         private LoggerInterface $logger,
-        private LoggerInterface $redirectLogger
+        private LoggerInterface $redirectLogger,
+        private GeneralHostResolver $generalHostResolver,
     ) {
         $this->lock = $lockFactory->createLock(self::class);
     }
@@ -174,7 +176,7 @@ final class RedirectHandler
                 }
             } else {
                 $site = Site::getByDomain($request->getHost());
-                $redirectDomain = $site instanceof Site ? $request->getHost() : $this->config['general']['domain'];
+                $redirectDomain = $site instanceof Site ? $request->getHost() : $this->generalHostResolver->resolve(['source' => $request]);
 
                 if ($redirectDomain) {
                     // prepend the host and scheme to avoid infinite loops when using "domain" redirects

--- a/bundles/StaticRoutesBundle/src/Routing/Staticroute/Router.php
+++ b/bundles/StaticRoutesBundle/src/Routing/Staticroute/Router.php
@@ -18,6 +18,7 @@ namespace OpenDxp\Bundle\StaticRoutesBundle\Routing\Staticroute;
 
 use OpenDxp\Bundle\StaticRoutesBundle\Model\Staticroute;
 use OpenDxp\Config;
+use OpenDxp\Http\Request\Host\GeneralHostResolver;
 use OpenDxp\Model\Site;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
@@ -55,8 +56,11 @@ final class Router implements RouterInterface, RequestMatcherInterface, Versatil
      */
     protected array $localeParams = [];
 
-    public function __construct(protected RequestContext $context, protected Config $config)
-    {
+    public function __construct(
+        protected RequestContext $context,
+        protected Config $config,
+        protected GeneralHostResolver $generalHostResolver,
+    ) {
     }
 
     public function setContext(RequestContext $context): void
@@ -123,8 +127,8 @@ final class Router implements RouterInterface, RequestMatcherInterface, Versatil
                         'route' => $name,
                     ]);
                 }
-            } elseif ($needsHostname && !empty($this->config['general']['domain'])) {
-                $hostname = $this->config['general']['domain'];
+            } elseif ($needsHostname) {
+                $hostname = $this->generalHostResolver->resolve();
             }
         }
 

--- a/doc/02_MVC/04_Routing_and_URLs/06_Domain_and_Host_Handling.md
+++ b/doc/02_MVC/04_Routing_and_URLs/06_Domain_and_Host_Handling.md
@@ -1,0 +1,122 @@
+# Domain and Host Handling
+
+## Introduction
+
+OpenDXP needs to know the "general" (main) host of your installation for various purposes: generating
+absolute URLs in CLI commands, building static page paths, resolving redirects without a site context,
+and more.
+
+For simple single-domain installations this is a static value from configuration. For multi-site
+installations the general domain may need to be determined dynamically – for example from site settings
+configured in the backoffice. The `GeneralHostResolver` service covers both cases without breaking
+existing setups.
+
+
+## Static Configuration (Simple Setups)
+
+For simple setups, define the main domain in your OpenDXP configuration:
+
+```yaml
+# config/packages/opendxp.yaml
+opendxp:
+    general:
+        domain: 'www.example.com'
+```
+
+An environment variable is also supported:
+
+```yaml
+opendxp:
+    general:
+        domain: '%env(APP_DOMAIN)%'
+```
+
+When a domain is configured here, OpenDXP sets Symfony's `router.request_context.host` parameter
+accordingly. This means CLI commands (where no HTTP request is available) will use this value as the
+default host for URL generation – the same behaviour as before this feature was introduced.
+
+> **Web requests** are not affected: Symfony overrides the router host from the actual request
+> automatically, so the configured value only matters in CLI context.
+
+
+## Dynamic Resolution via GeneralHostResolver
+
+The `OpenDxp\Http\Request\Host\GeneralHostResolver` service resolves the general host at runtime
+using the following priority order:
+
+1. **Registered providers** (tagged `opendxp.general_host_provider`), in descending tag priority.
+   The first provider that returns a non-null, non-empty string wins.
+2. **Static fallback** – the value of `opendxp.general.domain` from config (YAML / env).
+
+### Context
+
+All call sites may optionally pass a `$context` array to give providers additional information about
+the current execution environment:
+
+```php
+// in a web request
+$host = $this->generalHostResolver->resolve(['source' => $request]);
+
+// in a CLI command
+$host = $this->generalHostResolver->resolve(['source' => $input]);
+```
+
+Providers receive the same array and may use it however they see fit. Unknown keys are silently ignored.
+
+## Implementing a Custom Provider
+
+To participate in host resolution, implement `GeneralHostProviderInterface` and tag your service with
+`opendxp.general_host_provider`. Use the `priority` tag attribute to control ordering (higher wins):
+
+```php
+use OpenDxp\Http\Request\Host\GeneralHostProviderInterface;
+
+class MyGeneralHostProvider implements GeneralHostProviderInterface
+{
+    public function provide(array $context = []): ?string
+    {
+        // return null to pass through to the next provider / static config fallback
+        return $this->lookUpDomainSomehow();
+    }
+}
+```
+
+```yaml
+# config/services.yaml
+App\Host\MyGeneralHostProvider:
+    tags:
+        - { name: opendxp.general_host_provider, priority: 10 }
+```
+
+See [Dependency Injection Tags](../../20_Extending_OpenDxp/13_Dependency_Injection_Tags.md) for a
+complete list of available tags.
+
+
+## Multi-Site Setups
+
+In multi-site installations each site already has its own domain configured in the Document tree (see
+[Working with Sites](./08_Working_with_Sites.md)). For the *general* domain – used when no site context
+is available – you have two options:
+
+**Option A – Static config per environment**
+Set `opendxp.general.domain` in a per-environment config file or `.env`. Straightforward for setups
+where one environment always maps to one main domain.
+
+**Option B – Backoffice-driven (via site custom settings)**
+Mark one site as the "general" site through its custom settings in the backoffice. The admin-bundle
+provides a `GeneralHostProviderInterface` implementation that reads this setting from the database and
+returns the corresponding domain. No YAML configuration needed for the domain itself.
+
+Refer to the admin-bundle documentation for setup instructions:
+`open-dxp/admin-bundle` → `docs/20_Documents/01_Site_Custom_Settings.md`
+
+
+## CLI Context
+
+In CLI commands there is no HTTP request, so the resolved host depends entirely on what the providers
+(or the static config) return. If neither is configured, Symfony's built-in default (`localhost`) is
+used – the same fallback that existed before.
+
+Commands that are sensitive to the host context (e.g. generating absolute URLs for a specific site)
+should accept a `--site` option and pass the resolved site's domain explicitly rather than relying on
+the general host resolver.

--- a/doc/02_MVC/04_Routing_and_URLs/06_Domain_and_Host_Handling.md
+++ b/doc/02_MVC/04_Routing_and_URLs/06_Domain_and_Host_Handling.md
@@ -48,20 +48,13 @@ using the following priority order:
    The first provider that returns a non-null, non-empty string wins.
 2. **Static fallback** – the value of `opendxp.general.domain` from config (YAML / env).
 
-### Context
+### Passing Context to Providers
 
-All call sites may optionally pass a `$context` array to give providers additional information about
-the current execution environment:
+`resolve()` passes an optional `$context` array.
 
 ```php
-// in a web request
 $host = $this->generalHostResolver->resolve(['source' => $request]);
-
-// in a CLI command
-$host = $this->generalHostResolver->resolve(['source' => $input]);
 ```
-
-Providers receive the same array and may use it however they see fit. Unknown keys are silently ignored.
 
 ## Implementing a Custom Provider
 

--- a/doc/02_MVC/04_Routing_and_URLs/08_Working_with_Sites.md
+++ b/doc/02_MVC/04_Routing_and_URLs/08_Working_with_Sites.md
@@ -93,3 +93,10 @@ The functionality should be pretty self-explanatory:
 
 #### Document Preview Navigation with Sites
 Please keep in mind that when previewing documents that have links to different Sites, the navigation may not be working properly due the Iframe Content Security Policies and Cross-origin resource sharing (CORS) policy, please set your own security rules accordingly to your own needs.
+
+
+## General Domain in Multi-Site Setups
+
+When no request is available (e.g. in CLI commands) OpenDXP needs a fallback "general" domain that is
+independent of any specific site. See [Domain and Host Handling](./06_Domain_and_Host_Handling.md) for
+configuration options, including how to drive this value from site custom settings in the backoffice.

--- a/doc/20_Extending_OpenDxp/13_Dependency_Injection_Tags.md
+++ b/doc/20_Extending_OpenDxp/13_Dependency_Injection_Tags.md
@@ -6,6 +6,7 @@ In addition to the tags provided by Symfony, OpenDXP adds it's own tags to flag 
 
 Following an overview of all additional service tags provided by OpenDXP: 
  
-| Name                               | Usage                                                                           |
-|------------------------------------|---------------------------------------------------------------------------------|
-| `opendxp.area.brick`               | Used to register your [custom area bricks](../03_Documents/01_Editables/02_Areablock/02_Bricks.md), which are not loaded by the discovering service |
+| Name                            | Usage                                                                                                                                                             |
+|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `opendxp.area.brick`            | Used to register your [custom area bricks](../03_Documents/01_Editables/02_Areablock/02_Bricks.md), which are not loaded by the discovering service               |
+| `opendxp.general_host_provider` | Register a provider for the general (main) host of the installation. See [Domain and Host Handling](../02_MVC/04_Routing_and_URLs/06_Domain_and_Host_Handling.md) |

--- a/lib/Document/StaticPageGenerator.php
+++ b/lib/Document/StaticPageGenerator.php
@@ -20,11 +20,11 @@ namespace OpenDxp\Document;
 use Exception;
 use OpenDxp;
 use OpenDxp\Document\Renderer\DocumentRendererInterface;
+use OpenDxp\Http\Request\Host\GeneralHostResolver;
 use OpenDxp\Http\Request\Resolver\StaticPageResolver;
 use OpenDxp\Logger;
 use OpenDxp\Model\Document;
 use OpenDxp\Model\Site;
-use OpenDxp\SystemSettingsConfig;
 use OpenDxp\Tool\Storage;
 use Symfony\Component\Lock\LockFactory;
 
@@ -33,7 +33,7 @@ class StaticPageGenerator
     public function __construct(
         protected DocumentRendererInterface $documentRenderer,
         private readonly LockFactory $lockFactory,
-        protected SystemSettingsConfig $settingsConfig
+        private readonly GeneralHostResolver $generalHostResolver,
     ) {
     }
 
@@ -49,11 +49,10 @@ class StaticPageGenerator
 
         $useMainDomain = \OpenDxp\Config::getSystemConfiguration('documents')['static_page_generator']['use_main_domain'];
         if ($useMainDomain) {
-            $systemConfig = $this->settingsConfig->getSystemSettingsConfig();
-            $mainDomain = '/' . $systemConfig['general']['domain'];
+            $mainDomain = '/' . ($this->generalHostResolver->resolve() ?? '');
             $returnPath = '';
             $pathInfo = pathinfo($path);
-            if ($pathInfo['dirname'] != '') {
+            if ($pathInfo['dirname'] !== '') {
                 $directories = explode('/', $pathInfo['dirname']);
                 $directories = array_filter($directories);
                 $pathString = '';

--- a/lib/Http/Request/Host/GeneralHostProviderInterface.php
+++ b/lib/Http/Request/Host/GeneralHostProviderInterface.php
@@ -24,9 +24,7 @@ namespace OpenDxp\Http\Request\Host;
  * If no provider returns a value, the static `opendxp.general.domain` config is used as fallback.
  *
  * The optional $context array may carry arbitrary caller-supplied information, e.g.:
- *   ['source' => $consoleInput]
  *   ['source' => $request]
- *   ['source' => $site]
  */
 interface GeneralHostProviderInterface
 {

--- a/lib/Http/Request/Host/GeneralHostProviderInterface.php
+++ b/lib/Http/Request/Host/GeneralHostProviderInterface.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (https://pimcore.com)
+ * @copyright  Modification Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Http\Request\Host;
+
+/**
+ * Implement this interface and tag the service with `opendxp.general_host_provider`
+ * to participate in general host resolution.
+ *
+ * Providers are tried in descending priority order. The first non-null return value wins.
+ * If no provider returns a value, the static `opendxp.general.domain` config is used as fallback.
+ *
+ * The optional $context array may carry arbitrary caller-supplied information, e.g.:
+ *   ['source' => $consoleInput]
+ *   ['source' => $request]
+ *   ['source' => $site]
+ */
+interface GeneralHostProviderInterface
+{
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function provide(array $context = []): ?string;
+}

--- a/lib/Http/Request/Host/GeneralHostResolver.php
+++ b/lib/Http/Request/Host/GeneralHostResolver.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (https://pimcore.com)
+ * @copyright  Modification Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Http\Request\Host;
+
+final class GeneralHostResolver
+{
+    /**
+     * @param iterable<GeneralHostProviderInterface> $providers
+     */
+    public function __construct(
+        private readonly string $configuredDomain,
+        private readonly iterable $providers = [],
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function resolve(array $context = []): ?string
+    {
+        foreach ($this->providers as $provider) {
+            $domain = $provider->provide($context);
+            if ($domain !== null && $domain !== '') {
+                return $domain;
+            }
+        }
+
+        return $this->configuredDomain !== '' ? $this->configuredDomain : null;
+    }
+}

--- a/lib/Http/Request/Host/GeneralHostResolver.php
+++ b/lib/Http/Request/Host/GeneralHostResolver.php
@@ -16,15 +16,15 @@ declare(strict_types=1);
 
 namespace OpenDxp\Http\Request\Host;
 
+use OpenDxp\SystemSettingsConfig;
+
 final class GeneralHostResolver
 {
     /**
      * @param iterable<GeneralHostProviderInterface> $providers
      */
-    public function __construct(
-        private readonly string $configuredDomain,
-        private readonly iterable $providers = [],
-    ) {
+    public function __construct(private readonly iterable $providers = [])
+    {
     }
 
     /**
@@ -39,6 +39,14 @@ final class GeneralHostResolver
             }
         }
 
-        return $this->configuredDomain !== '' ? $this->configuredDomain : null;
+        return $this->getFallBackHost();
+    }
+
+    private function getFallBackHost(): ?string{
+
+        $systemConfig = SystemSettingsConfig::get()['general'];
+
+        return $systemConfig['domain'] ?? null;
+
     }
 }

--- a/lib/Tool.php
+++ b/lib/Tool.php
@@ -20,6 +20,7 @@ use Exception;
 use GuzzleHttp\RequestOptions;
 use Locale;
 use OpenDxp;
+use OpenDxp\Http\Request\Host\GeneralHostResolver;
 use OpenDxp\Http\RequestHelper;
 use OpenDxp\Localization\LocaleServiceInterface;
 use OpenDxp\Model\Element;
@@ -335,10 +336,10 @@ final class Tool
         $request = self::resolveRequest($request);
 
         if (!$request instanceof \Symfony\Component\HttpFoundation\Request || !$request->getHost()) {
-            $config = SystemSettingsConfig::get()['general'];
-            $domain = $config['domain'];
+            /** @var GeneralHostResolver $generalHostResolver */
+            $generalHostResolver = OpenDxp::getContainer()->get(GeneralHostResolver::class);
 
-            return $domain ?: null;
+            return $generalHostResolver->resolve(['source' => $request]);
         }
 
         return $request->getHost();
@@ -380,10 +381,10 @@ final class Tool
             }
         }
 
-        // get it from System settings
         if (!$hostname || $hostname === 'localhost') {
-            $systemConfig = SystemSettingsConfig::get()['general'];
-            $hostname = $systemConfig['domain'] ?? null;
+            /** @var GeneralHostResolver $generalHostResolver */
+            $generalHostResolver = OpenDxp::getContainer()->get(GeneralHostResolver::class);
+            $hostname = $generalHostResolver->resolve(['source' => $request]);
 
             if (!$hostname) {
                 Logger::warn('Couldn\'t determine HTTP Host. No Domain set in "Settings" -> "System" -> "Website" -> "Domain"');

--- a/models/Document.php
+++ b/models/Document.php
@@ -23,13 +23,13 @@ use OpenDxp\Cache\RuntimeCache;
 use OpenDxp\Event\DocumentEvents;
 use OpenDxp\Event\FrontendEvents;
 use OpenDxp\Event\Model\DocumentEvent;
+use OpenDxp\Http\Request\Host\GeneralHostResolver;
 use OpenDxp\Logger;
 use OpenDxp\Model\Document\Hardlink\Wrapper\WrapperInterface;
 use OpenDxp\Model\Document\Listing;
 use OpenDxp\Model\Element\DuplicateFullPathException;
 use OpenDxp\Model\Element\ElementInterface;
 use OpenDxp\Model\Exception\NotFoundException;
-use OpenDxp\SystemSettingsConfig;
 use OpenDxp\Tool;
 use OpenDxp\Tool\Frontend as FrontendTool;
 use Override;
@@ -719,7 +719,6 @@ class Document extends Element\AbstractElement
                 }
 
                 if (!$link) {
-                    $config = SystemSettingsConfig::get()['general'];
                     $scheme = 'http://';
                     if ($request) {
                         $scheme = $request->getScheme() . '://';
@@ -735,8 +734,13 @@ class Document extends Element\AbstractElement
                         }
                     }
 
-                    if (!$link && !empty($config['domain']) && !($this instanceof WrapperInterface)) {
-                        $link = $scheme . $config['domain'] . $this->getRealFullPath();
+                    if (!$link && !$this instanceof WrapperInterface) {
+                        /** @var GeneralHostResolver $generalHostResolver */
+                        $generalHostResolver = OpenDxp::getContainer()->get(GeneralHostResolver::class);
+                        $domain = $generalHostResolver->resolve();
+                        if (!empty($domain)) {
+                            $link = $scheme . $domain . $this->getRealFullPath();
+                        }
                     }
                 }
             }

--- a/models/Document/PageSnippet.php
+++ b/models/Document/PageSnippet.php
@@ -21,6 +21,7 @@ use OpenDxp;
 use OpenDxp\Document\Editable\EditableUsageResolver;
 use OpenDxp\Event\DocumentEvents;
 use OpenDxp\Event\Model\DocumentEvent;
+use OpenDxp\Http\Request\Host\GeneralHostResolver;
 use OpenDxp\Http\RequestHelper;
 use OpenDxp\Logger;
 use OpenDxp\Messenger\VersionDeleteMessage;
@@ -545,7 +546,9 @@ abstract class PageSnippet extends Model\Document
         }
 
         if (!$hostname) {
-            $hostname = \OpenDxp\Config::getSystemConfiguration('general')['domain'];
+            /** @var GeneralHostResolver $generalHostResolver */
+            $generalHostResolver = OpenDxp::getContainer()->get(GeneralHostResolver::class);
+            $hostname = $generalHostResolver->resolve();
             if (empty($hostname) && !$hostname = \OpenDxp\Tool::getHostname()) {
                 throw new Exception('No hostname available');
             }


### PR DESCRIPTION
- Replace direct usage of `SystemSettingsConfig` with the new `GeneralHostResolver` across multiple components (`RoutingListener`, `Document`, `RedirectHandler`, etc.) for improved domain resolution and maintainability.
- Add `opendxp.general_host_provider` service tag for extensible provider registration to support dynamic domain resolution.
- Provide updated developer documentation (`Domain and Host Handling`) detailing configuration and implementation guidelines for the `GeneralHostResolver`.
- Refactor domain-related logic in CLI and multi-site setups to leverage `GeneralHostResolver` for consistent behavior.

See new docs: https://github.com/open-dxp/opendxp/blob/7fdfc1891c0d06c21644fe87bb396f2d4eeeef4a/doc/02_MVC/04_Routing_and_URLs/06_Domain_and_Host_Handling.md