### PR TITLE
fix: Centralize brickPrefix handling in RelationFilterConditionParser

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Extension/RelationFilterConditionParser.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/RelationFilterConditionParser.php
@@ -28,21 +28,22 @@ trait RelationFilterConditionParser
     /**
      * Parses filter value of a relation field and creates the filter condition
      */
-    public function getRelationFilterCondition(?string $value, string $operator, string $name): string
+    public function getRelationFilterCondition(?string $value, string $operator, string $name, string $brickPrefix = ''): string
     {
         $db = \OpenDxp\Db::get();
-        $result = $db->quoteIdentifier($name) . ' IS NULL';
+        $key = $brickPrefix . $db->quoteIdentifier($name);
+        $result = $key . ' IS NULL';
         if ($value === null || $value === 'null') {
             return $result;
         }
         if ($operator === '=') {
-            return $db->quoteIdentifier($name) . ' = ' . $db->quote($value);
+            return $key . ' = ' . $db->quote($value);
         }
         $values = explode(',', $value);
-        $fieldConditions = array_map(function ($value) use ($name, $db) {
+        $fieldConditions = array_map(function ($value) use ($key, $db) {
             $quotedValue = $db->quote('%,' . Helper::escapeLike($value) . ',%');
 
-            return $db->quoteIdentifier($name) . ' LIKE ' . $quotedValue . ' ';
+            return $key . ' LIKE ' . $quotedValue . ' ';
         }, array_filter($values));
         if ($fieldConditions !== []) {
             return '(' . implode(' AND ', $fieldConditions) . ')';

--- a/models/DataObject/ClassDefinition/Data/Hotspotimage.php
+++ b/models/DataObject/ClassDefinition/Data/Hotspotimage.php
@@ -558,8 +558,9 @@ class Hotspotimage extends Data implements ResourcePersistenceAwareInterface, Qu
     {
         $name = $params['name'] ?: $this->name;
         $name .= '__image';
+        $brickPrefix = !empty($params['brickPrefix']) ? $params['brickPrefix'] : '';
 
-        return $this->getRelationFilterCondition($value, $operator, $name);
+        return $this->getRelationFilterCondition($value, $operator, $name, $brickPrefix);
     }
 
     public function getColumnType(): array

--- a/models/DataObject/ClassDefinition/Data/Image.php
+++ b/models/DataObject/ClassDefinition/Data/Image.php
@@ -276,8 +276,9 @@ class Image extends Data implements ResourcePersistenceAwareInterface, QueryReso
     public function getFilterConditionExt(mixed $value, string $operator, array $params = []): string
     {
         $name = $params['name'] ?: $this->name;
+        $brickPrefix = !empty($params['brickPrefix']) ? $params['brickPrefix'] : '';
 
-        return $this->getRelationFilterCondition($value, $operator, $name);
+        return $this->getRelationFilterCondition($value, $operator, $name, $brickPrefix);
     }
 
     public function getColumnType(): string

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -705,16 +705,10 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
     #[Override]
     public function getFilterConditionExt(mixed $value, string $operator, array $params = []): string
     {
-        $prefix = '';
         $name = $params['name'] ?: $this->name;
+        $brickPrefix = !empty($params['brickPrefix']) ? $params['brickPrefix'] : '';
 
-        if ($params['brickPrefix']) {
-            // The brick prefix is always quoted and with a dot suffix, so removing the first
-            // and second last character to unquote
-            $prefix = substr($params['brickPrefix'], 1, -2) . substr($params['brickPrefix'], -1);
-        }
-
-        return $this->getRelationFilterCondition($value, $operator, $prefix . $name);
+        return $this->getRelationFilterCondition($value, $operator, $name, $brickPrefix);
     }
 
     public function getQueryColumnType(): string

--- a/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
@@ -764,16 +764,10 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
     #[Override]
     public function getFilterConditionExt(mixed $value, string $operator, array $params = []): string
     {
-        $prefix = '';
         $name = $params['name'] ?: $this->name;
+        $brickPrefix = !empty($params['brickPrefix']) ? $params['brickPrefix'] : '';
 
-        if ($params['brickPrefix']) {
-            // The brick prefix is always quoted and with a dot suffix, so removing the first
-            // and second last character to unquote
-            $prefix = substr($params['brickPrefix'], 1, -2) . substr($params['brickPrefix'], -1);
-        }
-
-        return $this->getRelationFilterCondition($value, $operator, $prefix . $name);
+        return $this->getRelationFilterCondition($value, $operator, $name, $brickPrefix);
     }
 
     public function getQueryColumnType(): string

--- a/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToOneRelation.php
@@ -542,15 +542,16 @@ class ManyToOneRelation extends AbstractRelations implements QueryResourcePersis
         $name = $params['name'] . '__id';
         $prefix = $params['brickPrefix'] ?? '';
         if (preg_match('/^(asset|object|document)\|(\d+)/', $value, $matches)) {
+            $db = \OpenDxp\Db::get();
             $typeField = $params['name'] . '__type';
-            $typeCondition = '`' . $typeField . '` = ' . "'" . $matches[1] . "'";
+            $typeCondition = $prefix . $db->quoteIdentifier($typeField) . ' = ' . $db->quote($matches[1]);
             $value = $matches[2];
 
-            return '(' . $prefix . $typeCondition . ' AND ' . $prefix
-                . $this->getRelationFilterCondition($value, $operator, $name) . ')';
+            return '(' . $typeCondition . ' AND '
+                . $this->getRelationFilterCondition($value, $operator, $name, $prefix) . ')';
         }
 
-        return $this->getRelationFilterCondition($value, $operator, $name);
+        return $this->getRelationFilterCondition($value, $operator, $name, $prefix);
     }
 
     public function getVisibleFields(): ?string

--- a/models/DataObject/ClassDefinition/Data/Relations/ManyToManyRelationTrait.php
+++ b/models/DataObject/ClassDefinition/Data/Relations/ManyToManyRelationTrait.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace OpenDxp\Model\DataObject\ClassDefinition\Data\Relations;
 
-use OpenDxp\Db;
 use OpenDxp\Model\DataObject;
 use OpenDxp\Model\DataObject\Concrete;
 use OpenDxp\Model\DataObject\Fieldcollection\Data\AbstractData;
@@ -86,31 +85,9 @@ trait ManyToManyRelationTrait
      */
     public function getFilterConditionExt(mixed $value, string $operator, array $params = []): string
     {
-        $prefix = '';
         $name = $params['name'] ?: $this->name;
+        $brickPrefix = !empty($params['brickPrefix']) ? $params['brickPrefix'] : '';
 
-        if ($params['brickPrefix']) {
-            $prefix = $params['brickPrefix'];
-            // The brick prefix might be quoted and with a dot suffix, if so, removing the first
-            // and second last character to unquote
-            $quoteIdentifierSymbol  = substr(Db::get()->quoteIdentifier(''), 0, 1);
-
-            if (
-                substr($prefix, 0, 1) === $quoteIdentifierSymbol &&
-                substr($prefix, -2, 1) === $quoteIdentifierSymbol &&
-                str_ends_with($prefix, '.')
-            ) {
-                // Case: `db`.
-                $prefix = substr($prefix, 1, -2) . '.';
-            } elseif (
-                substr($prefix, 0, 1) === $quoteIdentifierSymbol &&
-                substr($prefix, -1) === $quoteIdentifierSymbol
-            ) {
-                // Case: `db`
-                $prefix = substr($prefix, 1, -1);
-            }
-        }
-
-        return $this->getRelationFilterCondition($value, $operator, $prefix . $name);
+        return $this->getRelationFilterCondition($value, $operator, $name, $brickPrefix);
     }
 }


### PR DESCRIPTION
Problem: Each relation field type (ManyToManyRelation, ManyToManyObjectRelation, ManyToManyRelationTrait, etc.) was independently and inconsistently handling the brickPrefix parameter — manually stripping quote characters from the prefix string before concatenating it with the column name. This was fragile, duplicated, and differed in implementation across files.

Solution: Move brickPrefix handling into the shared RelationFilterConditionParser::getRelationFilterCondition() method via a new 4th parameter (string $brickPrefix = ''). The prefix is simply prepended to the quoted column name: $key = $brickPrefix . $db->quoteIdentifier($name). This matches the established pattern used by other field types (Data.php:383, Select.php:306, Numeric.php:392, Multiselect.php:316).

We encountered this error while filtering a grid in admin by multi relation:
> Status: 500 | 
> URL: /admin/object/grid-proxy?classId=16&folderId=4&xaction=read&_dc=1774894872047
> Method: POST
> Message: An exception occurred while executing a query: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'bject_localized_16_e.categories' in 'WHERE'
> Trace: 
> in /serverpath/opendxp/vendor/doctrine/dbal/src/Driver/API/MySQL/ExceptionConverter.php:69
> #0 /serverpath/opendxp/vendor/doctrine/dbal/src/Connection.php(1976): Doctrine\DBAL\Driver\API\MySQL\ExceptionConverter->convert()
> #1 /serverpath/opendxp/vendor/doctrine/dbal/src/Connection.php(1918): Doctrine\DBAL\Connection->handleDriverException()
> #2 /serverpath/opendxp/vendor/doctrine/dbal/src/Connection.php(1111): Doctrine\DBAL\Connection->convertExceptionDuringQuery()
> #3 /serverpath/opendxp/vendor/doctrine/dbal/src/Connection.php(958): Doctrine\DBAL\Connection->executeQuery()
> #4 /serverpath/opendxp/vendor/open-dxp/opendxp/models/DataObject/Listing/Dao.php(101): Doctrine\DBAL\Connection->fetchFirstColumn()
> #5 /serverpath/opendxp/vendor/open-dxp/opendxp/models/DataObject/Listing/Concrete/Dao.php(50): OpenDxp\Model\DataObject\Listing\Dao->loadIdList()
> #6 /serverpath/opendxp/vendor/open-dxp/opendxp/models/DataObject/Listing/Dao.php(62): OpenDxp\Model\DataObject\Listing\Concrete\Dao->loadIdList()
> #7 [internal function]: OpenDxp\Model\DataObject\Listing\Dao->load()
> #8 /serverpath/opendxp/vendor/open-dxp/opendxp/lib/Model/AbstractModel.php(219): call_user_func_array()
> #9 /serverpath/opendxp/vendor/open-dxp/admin-bundle/src/Controller/Admin/DataObject/DataObjectActionsTrait.php(122): OpenDxp\Model\AbstractModel->__call()
> #10 /serverpath/opendxp/vendor/open-dxp/admin-bundle/src/Controller/Admin/DataObject/DataObjectController.php(1669): OpenDxp\Bundle\AdminBundle\Controller\Admin\DataObject\DataObjectController->gridProxy()
> #11 /serverpath/opendxp/vendor/symfony/http-kernel/HttpKernel.php(183): OpenDxp\Bundle\AdminBundle\Controller\Admin\DataObject\DataObjectController->gridProxyAction()
> #12 /serverpath/opendxp/vendor/symfony/http-kernel/HttpKernel.php(76): Symfony\Component\HttpKernel\HttpKernel->handleRaw()
> #13 /serverpath/opendxp/vendor/symfony/http-kernel/Kernel.php(193): Symfony\Component\HttpKernel\HttpKernel->handle()
> #14 /serverpath/opendxp/vendor/symfony/runtime/Runner/Symfony/HttpKernelRunner.php(35): Symfony\Component\HttpKernel\Kernel->handle()
> #15 /serverpath/opendxp/vendor/autoload_runtime.php(32): Symfony\Component\Runtime\Runner\Symfony\HttpKernelRunner->run()
> #16 /serverpath/opendxp/public/index.php(19): require_once('/serverpath/...')

This should properly handle the prefix parameters without breaking anything.