### PR TITLE
Translation: fix caching bugs and deprecate unused listing methods

### DIFF
--- a/lib/Translation/Translator.php
+++ b/lib/Translation/Translator.php
@@ -181,7 +181,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
 
                 $catalogue = new MessageCatalogue($locale, $data);
 
-                Cache::save($catalogue, $cacheKey, ['translator', 'translator_website', 'translate'], null, 999);
+                Cache::save($catalogue, $cacheKey, ['translator', 'translate'], null, 999);
             }
 
             $this->getCatalogue($locale)->addCatalogue($catalogue);

--- a/models/Translation/Listing.php
+++ b/models/Translation/Listing.php
@@ -33,6 +33,7 @@ class Listing extends Model\Listing\AbstractListing
 {
     /**
      * @internal
+     * @deprecated since OpenDXP 1.3 and will be removed in 2.0.
      *
      * @var int maximum number of cacheable items
      */
@@ -105,13 +106,23 @@ class Listing extends Model\Listing\AbstractListing
         return $this->setData($translations);
     }
 
+    /**
+     * @deprecated since OpenDXP 1.3 and will be removed in 2.0.
+     */
     public static function getCacheLimit(): int
     {
+        trigger_deprecation('open-dxp/opendxp', '1.3', 'Calling "%s::getCacheLimit()" is deprecated and will be removed in 2.0.', self::class);
+
         return self::$cacheLimit;
     }
 
+    /**
+     * @deprecated since OpenDXP 1.3 and will be removed in 2.0.
+     */
     public static function setCacheLimit(int $cacheLimit): void
     {
+        trigger_deprecation('open-dxp/opendxp', '1.3', 'Calling "%s::setCacheLimit()" is deprecated and will be removed in 2.0.', self::class);
+
         self::$cacheLimit = $cacheLimit;
     }
 }

--- a/models/Translation/Listing/Dao.php
+++ b/models/Translation/Listing/Dao.php
@@ -64,10 +64,19 @@ class Dao extends Model\Listing\Dao\AbstractDao
     {
         $queryBuilder = $this->getQueryBuilder('*');
         $cacheKey = $this->getDatabaseTableName().'_data_' . md5((string)$queryBuilder);
-        if (!empty($this->model->getConditionParams()) || !$translations = Cache::load($cacheKey)) {
+
+        $translations = Cache::load($cacheKey);
+        $hasCondition = !empty($this->model->getConditionParams()) || $this->model->getConditionVariablesFromSetCondition() !== null;
+
+        if ($hasCondition || !$translations) {
             $translations = [];
             $queryBuilder->setMaxResults(null); //retrieve all results
-            $translationsData = $this->db->fetchAllAssociative($queryBuilder->getSql(), $queryBuilder->getParameters(), $queryBuilder->getParameterTypes());
+
+            $translationsData = $this->db->fetchAllAssociative(
+                $queryBuilder->getSql(),
+                $queryBuilder->getParameters(),
+                $queryBuilder->getParameterTypes()
+            );
 
             foreach ($translationsData as $t) {
                 if (!isset($translations[$t['key']])) {
@@ -88,7 +97,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
                 $translations[$t['key']]->setModificationDate($t['modificationDate']);
             }
 
-            if (empty($this->model->getConditionParams())) {
+            if (!$hasCondition) {
                 Cache::save($translations, $cacheKey, ['translator', 'translate'], null, 999);
             }
         }
@@ -113,18 +122,31 @@ class Dao extends Model\Listing\Dao\AbstractDao
         $queryBuilder = $this->getQueryBuilder($this->getDatabaseTableName() . '.key');
         $cacheKey = $this->getDatabaseTableName().'_data_' . md5((string)$queryBuilder);
 
-        if (!empty($this->model->getConditionParams()) || !$translations = Cache::load($cacheKey)) {
+        $translations = Cache::load($cacheKey);
+        $hasCondition = !empty($this->model->getConditionParams()) || $this->model->getConditionVariablesFromSetCondition() !== null;
+
+        if ($hasCondition || !$translations) {
             $translations = [];
-            $translationsData = $this->db->fetchAllAssociative($queryBuilder->getSql(), $queryBuilder->getParameters(), $queryBuilder->getParameterTypes());
+
+            $translationsData = $this->db->fetchAllAssociative(
+                $queryBuilder->getSql(),
+                $queryBuilder->getParameters(),
+                $queryBuilder->getParameterTypes()
+            );
+
             foreach ($translationsData as $t) {
-                $transObj = Model\Translation::getByKey(id: $t['key'], domain: $this->model->getDomain(), languages: $this->model->getLanguages());
+                $transObj = Model\Translation::getByKey(
+                    id: $t['key'],
+                    domain: $this->model->getDomain(),
+                    languages: $this->model->getLanguages()
+                );
 
                 if ($transObj) {
                     $translations[] = $transObj;
                 }
             }
 
-            if (empty($this->model->getConditionParams())) {
+            if (!$hasCondition) {
                 Cache::save($translations, $cacheKey, ['translator', 'translate'], null, 999);
             }
         }

--- a/models/Translation/Listing/Dao.php
+++ b/models/Translation/Listing/Dao.php
@@ -60,8 +60,13 @@ class Dao extends Model\Listing\Dao\AbstractDao
         return (int) $this->db->fetchOne($query, $this->model->getConditionVariables(), $this->model->getConditionVariableTypes());
     }
 
+    /**
+     * @deprecated since OpenDXP 1.3 and will be removed in 2.0.
+     */
     public function getAllTranslations(): array
     {
+        trigger_deprecation('open-dxp/opendxp', '1.3', 'Calling "%s::getAllTranslations()" is deprecated and will be removed in 2.0.', self::class);
+
         $queryBuilder = $this->getQueryBuilder('*');
         $cacheKey = $this->getDatabaseTableName().'_data_' . md5((string)$queryBuilder);
 
@@ -156,8 +161,13 @@ class Dao extends Model\Listing\Dao\AbstractDao
         return $translations;
     }
 
+    /**
+     * @deprecated since OpenDXP 1.3 and will be removed in 2.0.
+     */
     public function isCacheable(): bool
     {
+        trigger_deprecation('open-dxp/opendxp', '1.3', 'Calling "%s::isCacheable()" is deprecated and will be removed in 2.0.', self::class);
+
         $count = $this->db->fetchOne(sprintf('SELECT COUNT(*) FROM %s', $this->getDatabaseTableName()));
         $cacheLimit = Model\Translation\Listing::getCacheLimit();
 

--- a/tests/Unit/Translation/TranslatorTest.php
+++ b/tests/Unit/Translation/TranslatorTest.php
@@ -227,6 +227,25 @@ class TranslatorTest extends TestCase
         $this->assertArrayNotHasKey('fr', $translationValues);
     }
 
+    public function testListingSetConditionWithDifferentParamsReturnsCorrectResults(): void
+    {
+        $list1 = new Translation\Listing();
+        $list1->setDomain('messages');
+        $list1->setCondition('`key` LIKE ?', ['simple%']);
+        $results1 = $list1->getTranslations();
+
+        $this->assertCount(1, $results1);
+        $this->assertEquals('simple_key', $results1[0]->getKey());
+
+        $list2 = new Translation\Listing();
+        $list2->setDomain('messages');
+        $list2->setCondition('`key` LIKE ?', ['fallback%']);
+        $results2 = $list2->getTranslations();
+
+        $this->assertCount(1, $results2);
+        $this->assertEquals('fallback_key', $results2[0]->getKey());
+    }
+
     public function testCacheGetsInvalidatedOnSave(): void
     {
         $translationsListing = new Translation\Listing();


### PR DESCRIPTION
Fix caching issues in translation listing and translator
                                                                                                                                                                                                                                                                                                                                                                                                         
  Changes:        
  - Fix `Listing\Dao::load()` and `getAllTranslations()` building cache keys from the SQL string only, without including bound parameter values. Queries with the same SQL structure but different parameter values (e.g. key LIKE ? with foo% vs. bar%) resolved to the same cache key, returning wrong cached results.
  - Remove stale cache tag `translator_website` from `Translator::lazyInitialize()` which creates orphaned cache tags                                                                                                                                                                                                                                                                                                                                             
  - Deprecate getAllTranslations(), isCacheable(), getCacheLimit(), and setCacheLimit() — none are used in the codebase (removal in 2.0)