### PR TITLE
Fix cross-site document path resolution in hardlink context

### DIFF
--- a/models/Document.php
+++ b/models/Document.php
@@ -36,6 +36,7 @@ use Override;
 use ReflectionClass;
 use Symfony\Cmf\Bundle\RoutingBundle\Routing\DynamicRouter;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @method \OpenDxp\Model\Document\Dao getDao()
@@ -684,63 +685,9 @@ class Document extends Element\AbstractElement
 
         $requestStack = OpenDxp::getContainer()->get('request_stack');
         $mainRequest = $requestStack->getMainRequest();
-        $request = $requestStack->getCurrentRequest();
 
-        // @TODO please forgive me, this is the dirtiest hack I've ever made :(
-        // if you got confused by this functionality drop me a line and I'll buy you some beers :)
-
-        // this is for the case that a link points to a document outside of the current site
-        // in this case we look for a hardlink in the current site which points to the current document
-        // why this could happen: we have 2 sites, in one site there's a hardlink to the other site and on a page inside
-        // the hardlink there are snippets embedded and this snippets have links pointing to a document which is also
-        // inside the hardlink scope, but this is an ID link, so we cannot rewrite the link the usual way because in the
-        // snippet / link we don't know anymore that whe a inside a hardlink wrapped document
         if (!$link && Tool::isFrontend()) {
-            $differentDomain = false;
-            $site = FrontendTool::getSiteForDocument($this);
-            if (Tool::isFrontendRequestByAdmin() && $site instanceof Site) {
-                $differentDomain = $site->getMainDomain() != $request->getHost();
-            }
-
-            if ((Site::isSiteRequest() && !FrontendTool::isDocumentInCurrentSite($this))
-                || $differentDomain) {
-                if ($mainRequest && ($mainDocument = $mainRequest->attributes->get(DynamicRouter::CONTENT_KEY)) && $mainDocument instanceof WrapperInterface) {
-                    $hardlinkPath = '';
-                    $hardlink = $mainDocument->getHardLinkSource();
-                    $hardlinkTarget = $hardlink->getSourceDocument();
-                    if ($hardlinkTarget) {
-                        $hardlinkPath = preg_replace('@^' . preg_quote(Site::getCurrentSite()->getRootPath(), '@') . '@', '', $hardlink->getRealFullPath());
-
-                        $link = preg_replace('@^' . preg_quote($hardlinkTarget->getRealFullPath(), '@') . '@', $hardlinkPath, $this->getRealFullPath());
-                    }
-                    if (!str_contains($link, $hardlinkPath) && !str_contains($this->getRealFullPath(), Site::getCurrentSite()->getRootDocument()->getRealFullPath())) {
-                        $link = null;
-                    }
-                }
-
-                if (!$link) {
-                    $scheme = sprintf('%s://', Tool::getRequestScheme($request));
-
-                    if ($site && $site->getMainDomain()) {
-                        // check if current document is the root of the different site, if so, preg_replace below doesn't work, so just return /
-                        if ($site->getRootDocument()->getId() === $this->getId()) {
-                            $link = $scheme . $site->getMainDomain() . '/';
-                        } else {
-                            $link = $scheme . $site->getMainDomain() .
-                                preg_replace('@^' . $site->getRootPath() . '/@', '/', $this->getRealFullPath());
-                        }
-                    }
-
-                    if (!$link && !$this instanceof WrapperInterface) {
-                        /** @var GeneralHostResolver $generalHostResolver */
-                        $generalHostResolver = OpenDxp::getContainer()->get(GeneralHostResolver::class);
-                        $domain = $generalHostResolver->resolve();
-                        if (!empty($domain)) {
-                            $link = $scheme . $domain . $this->getRealFullPath();
-                        }
-                    }
-                }
-            }
+            $link = $this->resolveCrossSiteFullPath($requestStack->getCurrentRequest(), $mainRequest);
         }
 
         if (!$link) {
@@ -754,6 +701,113 @@ class Document extends Element\AbstractElement
         }
 
         return $this->prepareFrontendPath($link);
+    }
+
+    /**
+     * Resolves the full path for a document that lives outside the current site.
+     *
+     * Two cases exist:
+     *
+     * Case 1 — Hardlink rewrite
+     *   The main request is rendering a hardlink-wrapped page (WrapperInterface).
+     *   Snippets on that page load linked documents via Document::getById(), which
+     *   always returns the real (unwrapped) source document — losing the hardlink
+     *   context. Without this method, those documents would produce paths pointing
+     *   to the source site instead of the current (hardlink) site.
+     *
+     *   Example tree:
+     *     Site A: domain-a.com => /site-a/en/section/
+     *     Site B: domain-b.com => /site-b/
+     *       Hardlink: /site-b/hl => /site-a/en/section (childrenFromSource)
+     *
+     *   Rendering domain-b.com/hl/page (WrapperInterface in main request):
+     *     - Snippet embeds a link to /site-a/en/section/subpage (by ID)
+     *     - Document::getById() returns the real document (no hardlink context)
+     *     - This method detects the WrapperInterface in the main request and
+     *       rewrites /site-a/en/section/subpage => /hl/subpage
+     *
+     * Case 2 — Absolute URL fallback
+     *   No hardlink context exists. The document belongs to a different site with
+     *   its own domain. Returns an absolute URL to that domain.
+     *   Falls back to GeneralHostResolver if no site domain is configured.
+     *
+     */
+    private function resolveCrossSiteFullPath(?Request $request, ?Request $mainRequest): ?string
+    {
+        $differentDomain = false;
+        $site = FrontendTool::getSiteForDocument($this);
+
+        if (Tool::isFrontendRequestByAdmin() && $site instanceof Site && $request !== null) {
+            $differentDomain = $site->getMainDomain() !== $request->getHost();
+        }
+
+        if (!$differentDomain && (!Site::isSiteRequest() || FrontendTool::isDocumentInCurrentSite($this))) {
+            return null;
+        }
+
+        // Case 1: Rewrite the path into the active hardlink scope of the current site.
+        $mainDocument = $mainRequest?->attributes->get(DynamicRouter::CONTENT_KEY);
+        if ($mainDocument instanceof WrapperInterface) {
+            $hardlink = $mainDocument->getHardLinkSource();
+            $hardlinkTarget = $hardlink->getSourceDocument();
+
+            if ($hardlinkTarget !== null) {
+                // Strip the current site root from the hardlink path.
+                // e.g. /site-b/hl => /hl (after stripping /site-b)
+                $hardlinkPath = preg_replace(
+                    sprintf('@^%s@', preg_quote(Site::getCurrentSite()->getRootPath(), '@')),
+                    '',
+                    $hardlink->getRealFullPath()
+                );
+
+                // Replace the hardlink-target prefix with the hardlink path.
+                // e.g. /site-a/en/section/subpage => /hl/subpage
+                $link = preg_replace(
+                    sprintf('@^%s@', preg_quote($hardlinkTarget->getRealFullPath(), '@')),
+                    $hardlinkPath,
+                    $this->getRealFullPath()
+                );
+
+                if (str_contains($link, $hardlinkPath)) {
+                    return $link;
+                }
+
+                // Rewrite did not match: document is not under the hardlink target.
+                // However, if the document is under the current site root (edge case with overlapping hardlink configurations),
+                // pass through unchanged.
+                if (str_contains($this->getRealFullPath(), Site::getCurrentSite()->getRootDocument()->getRealFullPath())) {
+                    return null;
+                }
+            }
+        }
+
+        // Case 2.1: Absolute URL using the document's own site domain.
+        $scheme = sprintf('%s://', Tool::getRequestScheme($request));
+
+        if ($site instanceof Site && $site->getMainDomain()) {
+
+            if ($site->getRootDocument()->getId() === $this->getId()) {
+                return sprintf('%s%s/', $scheme, $site->getMainDomain());
+            }
+
+            $pattern = sprintf('@^%s/@', preg_quote($site->getRootPath(), '@'));
+            $path = preg_replace($pattern, '/', $this->getRealFullPath());
+
+            return $scheme . $site->getMainDomain() . $path;
+        }
+
+        // Case 2.2: Absolute URL via GeneralHostResolver
+        if (!$this instanceof WrapperInterface) {
+            /** @var GeneralHostResolver $generalHostResolver */
+            $generalHostResolver = OpenDxp::getContainer()->get(GeneralHostResolver::class);
+            $domain = $generalHostResolver->resolve();
+
+            if (!empty($domain)) {
+                return sprintf('%s%s%s', $scheme, $domain, $this->getRealFullPath());
+            }
+        }
+
+        return null;
     }
 
     private function prepareFrontendPath(string $path): string

--- a/tests/Model/Document/HardlinkPathTest.php
+++ b/tests/Model/Document/HardlinkPathTest.php
@@ -1,0 +1,349 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenDxp\Tests\Model\Document;
+
+use OpenDxp;
+use OpenDxp\Cache\RuntimeCache;
+use OpenDxp\Http\RequestHelper;
+use OpenDxp\Model\Document;
+use OpenDxp\Model\Document\Hardlink\Service as HardlinkService;
+use OpenDxp\Model\Document\Hardlink\Wrapper\WrapperInterface;
+use OpenDxp\Model\Site;
+use OpenDxp\Tests\Support\Test\ModelTestCase;
+use OpenDxp\Tests\Support\Util\TestHelper;
+use ReflectionProperty;
+use Symfony\Cmf\Bundle\RoutingBundle\Routing\DynamicRouter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class HardlinkPathTest extends ModelTestCase
+{
+    private ?Site $siteA = null;
+
+    private ?Site $siteB = null;
+
+    private ?Document\Page $siteARoot = null;
+
+    private ?Document\Page $siteBRoot = null;
+
+    private ?Document\Page $siteASection = null;
+
+    private ?Document\Page $siteASubpage = null;
+
+    private ?Document\Hardlink $hardlink = null;
+
+    private RequestStack $requestStack;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->requestStack = OpenDxp::getContainer()->get('request_stack');
+    }
+
+    protected function tearDown(): void
+    {
+        while ($this->requestStack->getCurrentRequest() !== null) {
+            $this->requestStack->pop();
+        }
+
+        $ref = new ReflectionProperty(Site::class, 'currentSite');
+        $ref->setValue(null, null);
+
+        $this->siteA?->delete();
+        $this->siteB?->delete();
+
+        RuntimeCache::getInstance()->offsetUnset('sites_path_mapping');
+
+        parent::tearDown();
+    }
+
+    public function testSameSiteDocumentReturnsRelativePath(): void
+    {
+        $this->setUpSites();
+
+        $page = new Document\Page();
+        $page->setParentId($this->siteBRoot->getId());
+        $page->setKey('b-page');
+        $page->setPublished(true);
+        $page->save();
+
+        Site::setCurrentSite($this->siteB);
+        $this->pushFrontendRequest('http://domain-b.test/b-page');
+
+        $path = $page->getFullPath(true);
+
+        $this->assertStringNotContainsString('://', $path, 'Same-site document must not produce an absolute URL');
+        $this->assertSame('/b-page', $path);
+    }
+
+    public function testNoSiteRequestReturnsSimplePath(): void
+    {
+        // No Site::setCurrentSite() → isSiteRequest() = false
+        $page = TestHelper::createEmptyDocumentPage('no-site-');
+
+        $this->pushFrontendRequest('http://example.test/no-site-page');
+
+        $path = $page->getFullPath(true);
+
+        $this->assertStringNotContainsString('://', $path, 'Without a site request there must be no absolute URL');
+        $this->assertSame($page->getPath() . $page->getKey(), $path);
+    }
+
+    public function testCrossSiteDocumentWithHardlinkContextReturnsHardlinkRelativePath(): void
+    {
+        $this->setUpSites();
+
+        $wrappedHardlink = $this->getWrappedHardlink();
+
+        Site::setCurrentSite($this->siteB);
+        $this->pushFrontendRequest('http://domain-b.test/hl/', $wrappedHardlink);
+
+        $path = $this->siteASubpage->getFullPath(true);
+
+        $expectedHardlinkBase = str_replace(
+            $this->siteBRoot->getRealFullPath(),
+            '',
+            $this->hardlink->getRealFullPath()
+        );
+
+        $this->assertSame(
+            $expectedHardlinkBase . '/subpage',
+            $path,
+            'Cross-site document inside hardlink scope must be rewritten to the hardlink path'
+        );
+
+        $this->assertStringNotContainsString('://', $path, 'Result must be relative, not an absolute URL');
+    }
+
+    public function testCrossSiteRootDocumentReturnsAbsoluteUrlWithTrailingSlash(): void
+    {
+        $this->setUpSites();
+
+        Site::setCurrentSite($this->siteB);
+        $this->pushFrontendRequest('http://domain-b.test/');
+
+        $path = $this->siteARoot->getFullPath(true);
+
+        $this->assertSame('http://domain-a.test/', $path);
+    }
+
+    public function testCrossSiteDocumentWithoutHardlinkContextReturnsAbsoluteUrl(): void
+    {
+        $this->setUpSites();
+
+        Site::setCurrentSite($this->siteB);
+        // No WrapperInterface as CONTENT_KEY — plain page request on Site B
+        $this->pushFrontendRequest('http://domain-b.test/b-page');
+
+        $path = $this->siteASubpage->getFullPath(true);
+
+        $this->assertStringStartsWith(
+            'http://domain-a.test',
+            $path,
+            'Cross-site document without hardlink context must use the foreign site domain'
+        );
+        $this->assertStringContainsString('/section/subpage', $path);
+    }
+
+    public function testCrossSiteDocumentOutsideHardlinkSourceScopeFallsBackToAbsoluteUrl(): void
+    {
+        $this->setUpSites();
+
+        // A page directly under Site A root — NOT under /section (the hardlink source)
+        $otherPage = new Document\Page();
+        $otherPage->setParentId($this->siteARoot->getId());
+        $otherPage->setKey('other-page');
+        $otherPage->setPublished(true);
+        $otherPage->save();
+
+        $wrappedHardlink = $this->getWrappedHardlink();
+
+        Site::setCurrentSite($this->siteB);
+        $this->pushFrontendRequest('http://domain-b.test/hl/', $wrappedHardlink);
+
+        $path = $otherPage->getFullPath(true);
+
+        $this->assertStringStartsWith(
+            'http://domain-a.test',
+            $path,
+            'Document outside the hardlink source scope must produce an absolute URL to its own site'
+        );
+        $this->assertStringContainsString('/other-page', $path);
+    }
+
+    public function testNestedSnippetSubRequestStillUsesMainRequestHardlinkContext(): void
+    {
+        $this->setUpSites();
+
+        $wrappedHardlink = $this->getWrappedHardlink();
+
+        Site::setCurrentSite($this->siteB);
+
+        // Level 0 — main request: the hardlink-wrapped page
+        $this->pushFrontendRequest('http://domain-b.test/hl/', $wrappedHardlink);
+
+        // Level 1 — sub-request: a snippet rendered inside the page.
+        // The snippet is the real (unwrapped) document; CONTENT_KEY is a plain Snippet.
+        $snippet = TestHelper::createEmptyDocument('snippet-', true, true, Document\Snippet::class);
+        $subRequest = Request::create('http://domain-b.test/hl/');
+        $subRequest->attributes->set(RequestHelper::ATTRIBUTE_FRONTEND_REQUEST, true);
+        $subRequest->attributes->set(DynamicRouter::CONTENT_KEY, $snippet);
+        $this->requestStack->push($subRequest);
+
+        // Even though getCurrentRequest() has no WrapperInterface,
+        // the path for the cross-site subpage must still be rewritten.
+        $path = $this->siteASubpage->getFullPath(true);
+
+        $expectedHardlinkBase = str_replace(
+            $this->siteBRoot->getRealFullPath(),
+            '',
+            $this->hardlink->getRealFullPath()
+        );
+
+        $this->assertSame(
+            $expectedHardlinkBase . '/subpage',
+            $path,
+            'Hardlink path rewrite must work even when a sub-request (snippet) is the current request'
+        );
+
+        $this->requestStack->pop(); // remove sub-request
+    }
+
+    public function testBrokenHardlinkSourceDocumentDoesNotCauseTypeError(): void
+    {
+        $this->setUpSites();
+
+        $wrappedHardlink = $this->getWrappedHardlink();
+
+        $crossSitePage = new Document\Page();
+        $crossSitePage->setParentId($this->siteARoot->getId());
+        $crossSitePage->setKey('survivor-page');
+        $crossSitePage->setPublished(true);
+        $crossSitePage->save();
+
+        $this->siteASection->delete();
+        $this->siteASection = null;
+        $this->siteASubpage = null;
+
+        Site::setCurrentSite($this->siteB);
+        $this->pushFrontendRequest('http://domain-b.test/hl/', $wrappedHardlink);
+
+        $path = $crossSitePage->getFullPath(true);
+
+        $this->assertIsString($path, 'getFullPath() must return a string even with a broken hardlink source');
+        $this->assertStringStartsWith('http://', $path, 'Fallback must be an absolute URL when hardlink rewrite is impossible');
+    }
+
+    public function testCurrentSiteRootDocumentReturnsSlash(): void
+    {
+        $this->setUpSites();
+
+        Site::setCurrentSite($this->siteB);
+        $this->pushFrontendRequest('http://domain-b.test/');
+
+        $path = $this->siteBRoot->getFullPath(true);
+
+        $this->assertSame('/', $path);
+    }
+
+    public function testAdminPreviewFromDifferentDomainProducesAbsoluteUrl(): void
+    {
+        $this->setUpSites();
+
+        $request = Request::create('http://domain-b.test/some-path?opendxp_preview=1');
+        $request->attributes->set(RequestHelper::ATTRIBUTE_FRONTEND_REQUEST, true);
+        $this->requestStack->push($request);
+
+        $path = $this->siteASubpage->getFullPath(true);
+
+        $this->assertStringStartsWith('http://domain-a.test', $path);
+        $this->assertStringContainsString('/section/subpage', $path);
+    }
+
+    public function testCrossSiteDocumentWithNoSiteAndNoHostResolverReturnsTreePath(): void
+    {
+        $this->setUpSites();
+
+        $orphan = new Document\Page();
+        $orphan->setParentId(1);
+        $orphan->setKey('orphan-' . uniqid('', true));
+        $orphan->setPublished(true);
+        $orphan->save();
+
+        Site::setCurrentSite($this->siteB);
+        $this->pushFrontendRequest('http://domain-b.test/');
+
+        $path = $orphan->getFullPath(true);
+
+        // The code falls back to getPath() + getKey()
+        $this->assertIsString($path);
+        $this->assertStringNotContainsString('domain-b.test', $path, 'Orphan document must not be rewritten to Site B domain');
+    }
+
+    private function setUpSites(): void
+    {
+        RuntimeCache::getInstance()->offsetUnset('sites_path_mapping');
+
+        $this->siteARoot = TestHelper::createEmptyDocumentPage('site-a-root-');
+
+        $this->siteA = new Site();
+        $this->siteA->setRootId($this->siteARoot->getId());
+        $this->siteA->setMainDomain('domain-a.test');
+        $this->siteA->save();
+
+        $this->siteASection = new Document\Page();
+        $this->siteASection->setParentId($this->siteARoot->getId());
+        $this->siteASection->setKey('section');
+        $this->siteASection->setPublished(true);
+        $this->siteASection->save();
+
+        $this->siteASubpage = new Document\Page();
+        $this->siteASubpage->setParentId($this->siteASection->getId());
+        $this->siteASubpage->setKey('subpage');
+        $this->siteASubpage->setPublished(true);
+        $this->siteASubpage->save();
+
+        $this->siteBRoot = TestHelper::createEmptyDocumentPage('site-b-root-');
+
+        $this->siteB = new Site();
+        $this->siteB->setRootId($this->siteBRoot->getId());
+        $this->siteB->setMainDomain('domain-b.test');
+        $this->siteB->save();
+
+        $this->hardlink = new Document\Hardlink();
+        $this->hardlink->setParentId($this->siteBRoot->getId());
+        $this->hardlink->setKey('hl');
+        $this->hardlink->setSourceId($this->siteASection->getId());
+        $this->hardlink->setChildrenFromSource(true);
+        $this->hardlink->setPublished(true);
+        $this->hardlink->save();
+
+        RuntimeCache::getInstance()->offsetUnset('sites_path_mapping');
+    }
+
+    private function getWrappedHardlink(): WrapperInterface
+    {
+        $wrapped = HardlinkService::wrap($this->hardlink);
+        $this->assertInstanceOf(WrapperInterface::class, $wrapped);
+
+        return $wrapped;
+    }
+
+    private function pushFrontendRequest(string $url, mixed $contentDocument = null): Request
+    {
+        $request = Request::create($url);
+        $request->attributes->set(RequestHelper::ATTRIBUTE_FRONTEND_REQUEST, true);
+
+        if ($contentDocument !== null) {
+            $request->attributes->set(DynamicRouter::CONTENT_KEY, $contentDocument);
+        }
+
+        $this->requestStack->push($request);
+
+        return $request;
+    }
+
+}


### PR DESCRIPTION
Finaly, the beer is mine. This also fixes an edge case where documents belonging to the current site could receive a wrong path when the hardlink rewrite didn't match.

- Extract `resolveCrossSiteFullPath` method for handling hardlink rewrites and absolute URL fallbacks.
- Add `HardlinkPathTest` unit tests to validate edge case scenarios for cross-site documents.