### PR TITLE
fix: return exact language match before null-language fallback in `Asset::getMetadata()`

### DIFF
--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1527,28 +1527,28 @@ class Asset extends Element\AbstractElement
         bool $strictMatchLanguage = false,
         bool $raw = false
     ): mixed {
-        $result = null;
-        $data = null;
         if ($language === null) {
             $language = OpenDxp::getContainer()->get(LocaleServiceInterface::class)->findLocale();
         }
 
+        $fallback = null;
         foreach ($this->metadata as $md) {
             if ($md['name'] != $name) {
                 continue;
             }
-            if ($language == $md['language'] || (empty($md['language']) && !$strictMatchLanguage)) {
-                $data = $md;
-
-                break;
+            if ($language == $md['language']) {
+                return $raw ? $md : $this->transformMetadata($md);
+            }
+            if (!$strictMatchLanguage && empty($md['language']) && $fallback === null) {
+                $fallback = $md;
             }
         }
 
-        if ($data) {
-            return $raw ? $data : $this->transformMetadata($data);
+        if ($fallback !== null) {
+            return $raw ? $fallback : $this->transformMetadata($fallback);
         }
 
-        return $result;
+        return null;
     }
 
     public function getFileSize(bool $formatted = false, int $precision = 2): int|string

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -1533,10 +1533,10 @@ class Asset extends Element\AbstractElement
 
         $fallback = null;
         foreach ($this->metadata as $md) {
-            if ($md['name'] != $name) {
+            if ($md['name'] !== $name) {
                 continue;
             }
-            if ($language == $md['language']) {
+            if (($language ?: null) === ($md['language'] ?: null)) {
                 return $raw ? $md : $this->transformMetadata($md);
             }
             if (!$strictMatchLanguage && empty($md['language']) && $fallback === null) {

--- a/tests/Model/Asset/Metadata/NormalizerTest.php
+++ b/tests/Model/Asset/Metadata/NormalizerTest.php
@@ -248,4 +248,71 @@ class NormalizerTest extends ModelTestCase
 
         $this->doCompare($this->testAsset->getId(), $metaDataName, $originalData);
     }
+
+    /**
+     * Entries ordered: none → de → en
+     * getMetadata('alt', 'de') must return the 'de' value, not the fallback.
+     */
+    public function testLanguageSpecificEntryPrecedesEmptyLanguageFallback(): void
+    {
+        $asset = TestHelper::createImageAsset();
+        $asset->addMetadata('alt', 'input', 'test', null);
+        $asset->addMetadata('alt', 'input', 'test de', 'de');
+        $asset->addMetadata('alt', 'input', 'test en', 'en');
+        $asset->save();
+
+        $this->assertEquals('test de', $asset->getMetadata('alt', 'de'));
+        $this->assertEquals('test en', $asset->getMetadata('alt', 'en'));
+    }
+
+    /**
+     * When no language-specific entry exists, empty-language entry is the fallback.
+     */
+    public function testFallbackToEmptyLanguageWhenNoExactMatch(): void
+    {
+        $asset = TestHelper::createImageAsset();
+        $asset->addMetadata('alt', 'input', 'fallback', null);
+        $asset->addMetadata('alt', 'input', 'test de', 'de');
+        $asset->save();
+
+        $this->assertEquals('fallback', $asset->getMetadata('alt', 'it'));
+        $this->assertEquals('fallback', $asset->getMetadata('alt', 'fr'));
+    }
+
+    /**
+     * strictMatchLanguage=true returns the exact match when it exists.
+     */
+    public function testStrictMatchLanguageReturnsExactMatch(): void
+    {
+        $asset = TestHelper::createImageAsset();
+        $asset->addMetadata('alt', 'input', 'fallback', null);
+        $asset->addMetadata('alt', 'input', 'test de', 'de');
+        $asset->save();
+
+        $this->assertEquals('test de', $asset->getMetadata('alt', 'de', true));
+    }
+
+    /**
+     * Non-existent name returns null regardless of language.
+     */
+    public function testReturnsNullForUnknownName(): void
+    {
+        $asset = TestHelper::createImageAsset();
+        $asset->addMetadata('alt', 'input', 'value', null);
+        $asset->save();
+
+        $this->assertNull($asset->getMetadata('title', 'de'));
+    }
+
+    /**
+     * No fallback entry and no exact match → null.
+     */
+    public function testReturnsNullWhenNeitherFallbackNorExactMatchExists(): void
+    {
+        $asset = TestHelper::createImageAsset();
+        $asset->addMetadata('alt', 'input', 'test de', 'de');
+        $asset->save();
+
+        $this->assertNull($asset->getMetadata('alt', 'fr'));
+    }
 }


### PR DESCRIPTION
## Changes in this pull request

Fix `getMetadataByName` returning the null-language fallback entry instead of the                                                                                                                                                 
exact language match when the null-language entry appears before the specific-language                                                                                                                                            
entry in the metadata array.

**Root cause:** The original loop used a single condition combining exact match and                                                                                                                                               
fallback (`$language == $md['language'] || empty($md['language'])`) and broke on the                                                                                                                                              
first hit. When metadata was stored with `null` before `de`, requesting `de` returned                                                                                                                                             
the `null` entry.

**Fix:** The loop now returns immediately on an exact language match and only stores                                                                                                                                              
the null-language entry as a fallback candidate, which is returned only if no exact                                                                                                                                               
match is found.


## Additional info
* Regression tests added to NormalizerTest covering both the exact-match and fallback cases.
* Reproduction steps are documented below in the original issue.
* The bug only manifests when a null-language entry is stored before a language-specific entry in the metadata array — storage order determines behavior, which makes this especially hard to reproduce reliably.
* The previous workaround required two separate calls to getMetadataByName: one with $strictMatchLanguage = true to get the exact match, and a second with $strictMatchLanguage = false to get the fallback if the first returned nothing. This PR eliminates the need for that pattern.
* The $strictMatchLanguage flag is unaffected by this change — strict mode still skips null-language entries entirely, while non-strict mode now correctly prefers exact matches over fallbacks.

---

### Steps to reproduce

1. Upload an asset
2. Add three metadata entries with the same key, set language as follows: none, de, en
3. Save

<img width="510" height="204" alt="Image" src="https://github.com/user-attachments/assets/1024b087-9437-4deb-893f-07b9ccba9de4" />

### Actual Behavior

`Asset::getMetadata('alt', 'de')` is returning `test` as value.

### Expected Behavior

`Asset::getMetadata('alt', 'de')` **SHOULD** return `test de` as value.

---

The issue is because `Asset::getMetadataByName()` returns the wrong value when a metadata entry without a language appears before a language-specific entry. Because the method uses first-match logic and allows non-strict matching, it stops at the empty-language entry and never checks later entries with an exact language match (e.g. de). As a result, the fallback value is returned even though a language-specific value exists.

The correct value is returned when using `$strictMatchLanguage` is set to `true`, but then the fallback value (key without language set) is not used when visiting from another locale (like `it`). This means that the current workaround requires two calls to that function to have a proper fallback possible.

This behaviour is really confusing and should be changed, especially as it is prefering a fallback value before actual language matches.

**Suggested fixes:**
* **Reorder metadata before matching:**
Sort entries so language-specific variants are evaluated before empty-language (fallback) entries.

* **Two-pass lookup:**
First search using strict language matching, then fall back to empty-language entries only if no match was found.

* **Track best match during iteration:**
Continue iterating instead of breaking early and prefer exact language matches over fallbacks.

---

```twig
{{ dump(
      mediaobject.metadata,
      mediaobject.getMetadata('alt', app.request.locale),
      mediaobject.getMetadata('alt', app.request.locale, true)
) }}
```
<img width="240" height="407" alt="Image" src="https://github.com/user-attachments/assets/66bb51a8-aff9-4100-8a39-63ce2b9b992f" />

---