### PR TITLE
Refactor schema filter logic for unmanaged tables

### DIFF
--- a/bundles/CoreBundle/config/event_listeners.yaml
+++ b/bundles/CoreBundle/config/event_listeners.yaml
@@ -94,7 +94,7 @@ services:
     #
     # Doctrine Listeners
 
-    OpenDxp\Bundle\CoreBundle\EventListener\Doctrine\IgnoreCoreTablesFilterListener: ~
+    OpenDxp\Bundle\CoreBundle\EventListener\Doctrine\UnmanagedTablesSchemaFilter: ~
 
     #
     # Frontend Listeners

--- a/bundles/CoreBundle/src/Doctrine/ExcludesUnmanagedTablesInterface.php
+++ b/bundles/CoreBundle/src/Doctrine/ExcludesUnmanagedTablesInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Bundle\CoreBundle\Doctrine;
+
+/**
+ * Implement this interface on a console command to apply the same schema filter
+ * that doctrine:schema:update and doctrine:schema:validate use automatically:
+ *
+ * Non-ORM tables are invisible to schema comparisons, preventing unintended
+ * DROP TABLE statements for tables Doctrine does not manage.
+ */
+interface ExcludesUnmanagedTablesInterface
+{
+}

--- a/bundles/CoreBundle/src/EventListener/Doctrine/UnmanagedTablesSchemaFilter.php
+++ b/bundles/CoreBundle/src/EventListener/Doctrine/UnmanagedTablesSchemaFilter.php
@@ -17,10 +17,11 @@ declare(strict_types=1);
 namespace OpenDxp\Bundle\CoreBundle\EventListener\Doctrine;
 
 use Doctrine\DBAL\Schema\AbstractAsset;
-use Doctrine\Migrations\Tools\Console\Command\DoctrineCommand;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand;
+use Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand;
 use Doctrine\Persistence\ManagerRegistry;
-use OpenDxp\Bundle\CoreBundle\Command\Bundle\InstallCommand;
+use OpenDxp\Bundle\CoreBundle\Doctrine\ExcludesUnmanagedTablesInterface;
 use Override;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
@@ -28,13 +29,13 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 #[AutoconfigureTag('doctrine.dbal.schema_filter')]
-class IgnoreCoreTablesFilterListener implements EventSubscriberInterface
+class UnmanagedTablesSchemaFilter implements EventSubscriberInterface
 {
-    private bool $enabled = true;
+    private bool $enabled = false;
 
     protected bool $initialized = false;
 
-    protected array $coreTables;
+    protected array $managedTables;
 
     public function __construct(protected ManagerRegistry $managerRegistry)
     {
@@ -52,7 +53,7 @@ class IgnoreCoreTablesFilterListener implements EventSubscriberInterface
 
         $this->loadManagedTables();
 
-        return in_array($assetName, $this->coreTables, true);
+        return in_array($assetName, $this->managedTables, true);
     }
 
     private function loadManagedTables(): void
@@ -62,12 +63,12 @@ class IgnoreCoreTablesFilterListener implements EventSubscriberInterface
         }
 
         $this->initialized = true;
-        $this->coreTables = [];
+        $this->managedTables = [];
 
         foreach ($this->managerRegistry->getManagers() as $em) {
             foreach ($em->getMetadataFactory()->getAllMetadata() as $metadata) {
-                if ($metadata instanceof ClassMetadata && !in_array($metadata->getTableName(), $this->coreTables, true)) {
-                    $this->coreTables[] = $metadata->getTableName();
+                if ($metadata instanceof ClassMetadata && !in_array($metadata->getTableName(), $this->managedTables, true)) {
+                    $this->managedTables[] = $metadata->getTableName();
                 }
             }
         }
@@ -75,11 +76,10 @@ class IgnoreCoreTablesFilterListener implements EventSubscriberInterface
 
     public function onConsoleCommand(ConsoleCommandEvent $event): void
     {
-        if ($event->getCommand() instanceof DoctrineCommand) {
-            $this->enabled = false;
-        } elseif ($event->getCommand() instanceof InstallCommand) {
-            $this->enabled = false;
-        }
+        $command = $event->getCommand();
+        $this->enabled = $command instanceof UpdateCommand
+            || $command instanceof ValidateSchemaCommand
+            || $command instanceof ExcludesUnmanagedTablesInterface;
     }
 
     #[Override]

--- a/doc/19_Development_Tools_and_Details/06_Doctrine_Schema_Filter.md
+++ b/doc/19_Development_Tools_and_Details/06_Doctrine_Schema_Filter.md
@@ -1,0 +1,50 @@
+# Doctrine Schema Filter
+
+OpenDXP registers a DBAL schema filter (`UnmanagedTablesSchemaFilter`) that limits Doctrine's
+view of the database to only the tables it manages as ORM entities.
+
+When active, any table not mapped to a Doctrine entity is invisible to schema comparisons.
+This prevents `doctrine:schema:update` from generating `DROP TABLE` statements for tables that
+OpenDXP or third-party bundles manage outside of the ORM (e.g. via raw SQL or a separate
+migration system).
+
+## Default behaviour
+
+The filter is **disabled by default**. It activates automatically for:
+
+- `doctrine:schema:update`
+- `doctrine:schema:validate`
+- Any console command implementing `ExcludesUnmanagedTablesInterface`
+
+At runtime (outside of these commands) all tables are visible, which is required for features
+that inspect the schema directly (e.g. checking whether a table already exists).
+
+## ExcludesUnmanagedTablesInterface
+
+```
+OpenDxp\Bundle\CoreBundle\Doctrine\ExcludesUnmanagedTablesInterface
+```
+
+Implement this marker interface on a console command that calls `SchemaTool::updateSchema()`
+directly. It signals the filter to activate for the duration of that command — the same
+protection that `doctrine:schema:update` gets automatically.
+
+Without the filter, `SchemaTool::updateSchema()` compares all database tables against the
+provided metadata and generates `DROP TABLE` statements for every table it does not recognise.
+
+### When to use it
+
+Use it whenever a command calls `SchemaTool::updateSchema()` or `SchemaTool::getUpdateSchemaSql()`
+with a partial set of metadata (i.e. not all ORM entities, but only those relevant to the command).
+
+### Example
+
+```php
+use OpenDxp\Bundle\CoreBundle\Doctrine\ExcludesUnmanagedTablesInterface;
+use Symfony\Component\Console\Command\Command;
+
+final class CreateDatabaseTablesCommand extends Command implements ExcludesUnmanagedTablesInterface
+{
+    // ...
+}
+```

--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,5 +1,9 @@
 # Upgrade Notes
 
+## OpenDXP 1.3.2
+- Improvement: `UnmanagedTablesSchemaFilter` (formally `IgnoreCoreTablesFilterListener`) is now disabled by default and only activates during `doctrine:schema:update`, `doctrine:schema:validate`, and commands implementing `ExcludesUnmanagedTablesInterface`
+  - New Feature: If `ExcludesUnmanagedTablesInterface` is implemented on any console command that calls `SchemaTool::updateSchema()` directly to prevent unintended DROP TABLE statements for non-ORM tables, see [docs](../../19_Development_Tools_and_Details/06_Doctrine_Schema_Filter.md)
+
 ## OpenDXP 1.3.1
 - Bugfix: Centralize brickPrefix handling in RelationFilterConditionParser [#120](https://github.com/open-dxp/opendxp/pull/120)
 - Bugfix: fix translation caching bugs and deprecate unused listing methods [#123](https://github.com/open-dxp/opendxp/pull/123)


### PR DESCRIPTION
Replaced `IgnoreCoreTablesFilterListener` with `UnmanagedTablesSchemaFilter` for improved clarity. Introduced `ExcludesUnmanagedTablesInterface` to prevent unintended `DROP TABLE` statements during schema updates, with updated behavior documented and integrated into affected commands.

Docs: https://github.com/open-dxp/opendxp/blob/81dcf00c9a5c85b0c3668f09e5a77beed75c01fa/doc/19_Development_Tools_and_Details/06_Doctrine_Schema_Filter.md