### PR TITLE
Add `forceResize` parameter to video scaling methods 

### DIFF
--- a/doc/04_Assets/03_Working_with_Thumbnails/03_Video_Thumbnails.md
+++ b/doc/04_Assets/03_Working_with_Thumbnails/03_Video_Thumbnails.md
@@ -1,83 +1,116 @@
 # Video Thumbnails
-OpenDXP is able to convert any video to web formats automatically. It is also possible capture a 
-custom preview image out of the video.
 
-> **IMPORTANT** 
-> To use all the following functionalities it is required to install FFMPEG on the server.  
-> For details, please have a look at [Additional Tools Installation](../../23_Installation_and_Upgrade/03_System_Setup_and_Hosting/06_Additional_Tools_Installation.md).
+OpenDXP can transcode uploaded videos into web-ready formats and extract still images at any point in time. 
+Transcoding runs asynchronously via the message queue — the result is not immediately available after the first request.
 
-## Explanation of the Transformations
+> [!NOTE]
+> **Requires ffmpeg**  
+> All transcoding features depend on ffmpeg being installed on the server.  
+> See [Additional Tools Installation](../../23_Installation_and_Upgrade/03_System_Setup_and_Hosting/06_Additional_Tools_Installation.md) for setup instructions.
 
-> The transfomations are adapters for the [FFMPEG Filters and Options](https://ffmpeg.org/documentation.html) and most of the configuration is equivalent.
+---
 
-| Transformation | Description | FFMPEG-Filter |
-|----------------|-------------|---------------|
-| ORIGINAL VIDEO | This is the video which is used in the following transformations | NONE ;-) |
-| COLOR CHANEL MIXER | Adjust video input frames by re-mixing color channels | [`-fv colorchannelmixer`](https://ffmpeg.org/ffmpeg-filters.html#colorchannelmixer) |
-| SET FRAMERATE | Convert the video to specified constant frame rate by duplicating or dropping frames as necessary| [`-fv fps`](https://ffmpeg.org/ffmpeg-filters.html#fps-1) |
-| CUT | Set video starging and endig position | [`-ss` and `-t`](https://ffmpeg.org/ffmpeg.html#Main-options) |
-| MUTE | Remove the audio stream | [`-an`](https://ffmpeg.org/ffmpeg.html#Audio-Options) |
+## Transformations
+A video thumbnail configuration is a named pipeline of transformations applied in sequence. Each transformation maps to an ffmpeg filter or option.
 
+| Transformation      | Description                                                                               | Option / Filter                                                                     |
+|---------------------|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| Resize              | Scale to exact dimensions, ignoring aspect ratio                                          | [`-s WxH`](https://ffmpeg.org/ffmpeg.html#Video-Options)                            |
+| Scale by Width      | Scale proportionally to a target width. Optionally skip if the video is already smaller.  | [`-vf scale`](https://ffmpeg.org/ffmpeg-filters.html#scale-1)                       |
+| Scale by Height     | Scale proportionally to a target height. Optionally skip if the video is already smaller. | [`-vf scale`](https://ffmpeg.org/ffmpeg-filters.html#scale-1)                       |
+| Cut                 | Trim the video to a start time and duration                                               | [`-ss` and `-t`](https://ffmpeg.org/ffmpeg.html#Main-options)                       |
+| Set Framerate       | Convert to a constant frame rate by duplicating or dropping frames                        | [`-vf fps`](https://ffmpeg.org/ffmpeg-filters.html#fps-1)                           |
+| Color Channel Mixer | Adjust color channels — useful for effects like grayscale or sepia                        | [`-vf colorchannelmixer`](https://ffmpeg.org/ffmpeg-filters.html#colorchannelmixer) |
+| Mute                | Remove the audio stream entirely                                                          | [`-an`](https://ffmpeg.org/ffmpeg.html#Audio-Options)                               |
 
-## Using Video Thumbnails in your Code
+### Force Resize
 
-### Examples - Image Snapshots
+The **Scale by Width** and **Scale by Height** transformations include a **Force Resize** option (enabled by default).
+
+When **Force Resize is on**, the video is always scaled to the configured dimension — even if the source is smaller, which causes upscaling.  
+When **Force Resize is off**, the transformation is skipped if the source video is already smaller than the target. 
+
+This prevents quality loss from upscaling, which is especially relevant for vertical or low-resolution uploads.
+
+---
+
+## Working with Video Thumbnails in Code
+
+### Image Snapshots
+
+You can extract a still image from any video, optionally combined with an image thumbnail configuration for resizing.
+
 ```php
 $asset = Asset::getById(123);
-if($asset instanceof Asset\Video) {
- 
-   // get a preview image thumbnail of the video, resized to the configuration of "myThumbnail"
-   echo $asset->getImageThumbnail("myThumbnail");
- 
-   // get a snapshot (image) out of the video at the time of 10 secs. (see second parameter) using a dynamic image thumbnail configuration
-   echo $asset->getImageThumbnail(["width" => 250], 10);
+
+if ($asset instanceof Asset\Video) {
+    // Preview image using a named image thumbnail config
+    echo $asset->getImageThumbnail('myThumbnail');
+
+    // Snapshot at a specific time offset (in seconds)
+    echo $asset->getImageThumbnail(['width' => 250], 10);
 }
 ```
 
-### Examples - Video Transcoding
+### Video Transcoding
+
+Transcoding is asynchronous. The first call to `getThumbnail()` dispatches a conversion job to the message queue. Subsequent calls return the current status until the job is complete.
+
 ```php
 $asset = Asset::getById(123);
-if($asset instanceof Asset\Video) {
- 
-   $thumbnail = $asset->getThumbnail("myVideoThumbnail"); // returns an array
-   if($thumbnail["status"] == "finished") {
-      p_r($thumbnail["formats"]); // transcoding finished, print the paths to the different formats
-      /*
-         OUTPUTS:
-         Array(
-             "mp4" => "/Sample%20Content/Videos/123/video-thumb__123__myVideoThumbnail...mp4",
-             "webm" => "/Sample%20Content/Videos/123/video-thumb__123__myVideoThumbnail...webm"
-         )
-      */
-   } else if ($thumbnail["status"] == "inprogress")  {
-      echo "transcoding in progress, please wait ...";
-   } else {
-      echo "transcoding failed :(";
-   }
+
+if ($asset instanceof Asset\Video) {
+    $thumbnail = $asset->getThumbnail('myVideoThumbnail');
+
+    echo match ($thumbnail['status']) {
+        'finished'   => 'Ready: ' . $thumbnail['formats']['mp4'],
+        'inprogress' => 'Transcoding in progress — check back shortly.',
+        'error'      => 'Transcoding failed. Check the logs for details.',
+        default      => 'Queued.',
+    };
 }
 ```
 
-### Adaptive bitrate video-streaming
-This feature allows you to generate a MPEG-DASH (.mpd) file for Adaptive  bitrate video-streaming.
+The `formats` array contains storage paths for each generated format, for example:
 
-As soon as you define transformations based on the bitrates in thumbnail config, the `.mpd` file will be generated with bitrate streams. 
-The `.mpd` file will be referenced in  generated `<video>` Tag.
+```php
+[
+    'mp4'  => '/videos/123/video-thumb__123__myVideoThumbnail/clip.mp4',
+    'webm' => '/videos/123/video-thumb__123__myVideoThumbnail/clip.webm',
+]
+```
 
-However, you have to include a polyfill for all major browsers to support Adaptive  bitrate video-streaming: https://github.com/Dash-Industry-Forum/dash.js
+---
+
+## Adaptive Bitrate Streaming (MPEG-DASH)
+
+When a thumbnail configuration contains **media segments** (multiple bitrate variants), OpenDXP generates an additional `.mpd` manifest file alongside the regular formats. 
+This enables adaptive bitrate streaming via MPEG-DASH — the player automatically selects the appropriate quality level based on the viewer's available bandwidth.
+
+To play `.mpd` streams in all browsers, include a DASH player such as [dash.js](https://github.com/Dash-Industry-Forum/dash.js).
+
+The `opendxp_video` Twig tag handles source selection automatically:
+
 ```twig
-{{ opendxp_video('campaignVideo', {
-        width: auto,
-        height: auto,
-        thumbnail: 'new'
-    }) }}
+{{ opendxp_video(asset, {
+    thumbnail: 'myVideoThumbnail'
+}) }}
 ```
-generates frontend:
+
+Rendered output (example):
+
 ```html
-<video width="100%" height="auto" controls="controls" class="opendxp_video" preload="auto" src="blob:http://xyz/01f91372-ddd8-4d3f-ac85-e420432d9704">
-    <source type="video/mp4" src="/videodata/955/video-thumb__955__campaignVideo/Volkswagen-Van.mp4">
-    <source type="application/dash+xml" src="/videodata/955/video-thumb__955__campaignVideo/Volkswagen-Van.mpd">
+<video controls preload="auto" class="opendxp_video">
+    <source type="video/mp4" src="/videos/955/video-thumb__955__myVideoThumbnail/clip.mp4">
+    <source type="application/dash+xml" src="/videos/955/video-thumb__955__myVideoThumbnail/clip.mpd">
 </video>
 ```
 
-## Using with the Video Editable
-Please have a look at [Video Editable](../../03_Documents/01_Editables/38_Video.md). 
+When a `.mpd` source is present, a DASH-capable player will prefer it and adapt quality dynamically. Browsers without DASH support fall back to the `mp4` source.
+
+---
+
+## Related
+
+- [Video Editable](../../03_Documents/01_Editables/38_Video.md)
+- [Additional Tools Installation](../../23_Installation_and_Upgrade/03_System_Setup_and_Hosting/06_Additional_Tools_Installation.md)

--- a/lib/Video/Adapter/Ffmpeg.php
+++ b/lib/Video/Adapter/Ffmpeg.php
@@ -405,18 +405,26 @@ class Ffmpeg extends Adapter
         $this->addArgument('-s', $width.'x'.$height);
     }
 
-    public function scaleByWidth(int $width): void
+    public function scaleByWidth(int $width, bool $forceResize = true): void
     {
         // ensure $width is even (mp4 requires this)
-        $width = ceil($width / 2) * 2;
-        $this->videoFilter[] = 'scale='.$width.':trunc(ow/a/2)*2';
+        $width = (int) (ceil($width / 2) * 2);
+        if ($forceResize) {
+            $this->videoFilter[] = sprintf('scale=%d:trunc(ow/a/2)*2', $width);
+        } else {
+            $this->videoFilter[] = sprintf('scale=if(gte(iw\,%d)\,%d\,iw):trunc(ow/a/2)*2', $width, $width);
+        }
     }
 
-    public function scaleByHeight(int $height): void
+    public function scaleByHeight(int $height, bool $forceResize = true): void
     {
         // ensure $height is even (mp4 requires this)
-        $height = ceil($height / 2) * 2;
-        $this->videoFilter[] = 'scale=trunc(oh/(ih/iw)/2)*2:'.$height;
+        $height = (int) (ceil($height / 2) * 2);
+        if ($forceResize) {
+            $this->videoFilter[] = sprintf('scale=trunc(oh/(ih/iw)/2)*2:%d', $height);
+        } else {
+            $this->videoFilter[] = sprintf('scale=trunc(oh/(ih/iw)/2)*2:if(gte(ih\,%d)\,%d\,ih)', $height, $height);
+        }
     }
 
     public function cut(?string $inputSeeking = null, ?string $targetDuration = null): void

--- a/models/Asset/Video/Thumbnail/Processor.php
+++ b/models/Asset/Video/Thumbnail/Processor.php
@@ -34,8 +34,8 @@ class Processor
 {
     protected static array $argumentMapping = [
         'resize'            => ['width', 'height'],
-        'scaleByWidth'      => ['width'],
-        'scaleByHeight'     => ['height'],
+        'scaleByWidth'      => ['width', 'forceResize'],
+        'scaleByHeight'     => ['height', 'forceResize'],
         'cut'               => ['start', 'duration'],
         'setFramerate'      => ['fps'],
         'colorChannelMixer' => ['effect'],
@@ -179,11 +179,10 @@ class Processor
                 }
 
                 ksort($arguments);
-                if (count($mapping) === count($arguments)) {
+                if (method_exists($converter, $transformation['method'])) {
                     call_user_func_array([$converter, $transformation['method']], $arguments);
                 } else {
-                    $message = 'Video Transform failed: cannot call method `' . $transformation['method'] . '´ with arguments `' . implode(',', $arguments) . '´ because there are too few arguments';
-                    Logger::error($message);
+                    Logger::error(sprintf('Video Transform failed: unknown method `%s`', $transformation['method']));
                 }
             }
         }

--- a/tests/Unit/Video/Adapter/FfmpegTest.php
+++ b/tests/Unit/Video/Adapter/FfmpegTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Tests\Unit\Video\Adapter;
+
+use OpenDxp\Tests\Support\Test\TestCase;
+use OpenDxp\Video\Adapter\Ffmpeg;
+
+class FfmpegTest extends TestCase
+{
+    private function getVideoFilter(Ffmpeg $ffmpeg): array
+    {
+        $prop = new \ReflectionProperty(Ffmpeg::class, 'videoFilter');
+
+        return $prop->getValue($ffmpeg);
+    }
+
+    public function testScaleByWidthDefaultIsForceResize(): void
+    {
+        $ffmpeg = new Ffmpeg();
+        $ffmpeg->scaleByWidth(500);
+
+        $this->assertSame(['scale=500:trunc(ow/a/2)*2'], $this->getVideoFilter($ffmpeg));
+    }
+
+    public function testScaleByWidthNoForceResize(): void
+    {
+        $ffmpeg = new Ffmpeg();
+        $ffmpeg->scaleByWidth(500, false);
+
+        $this->assertSame(['scale=if(gte(iw\,500)\,500\,iw):trunc(ow/a/2)*2'], $this->getVideoFilter($ffmpeg));
+    }
+
+    public function testScaleByHeightDefaultIsForceResize(): void
+    {
+        $ffmpeg = new Ffmpeg();
+        $ffmpeg->scaleByHeight(300);
+
+        $this->assertSame(['scale=trunc(oh/(ih/iw)/2)*2:300'], $this->getVideoFilter($ffmpeg));
+    }
+
+    public function testScaleByHeightNoForceResize(): void
+    {
+        $ffmpeg = new Ffmpeg();
+        $ffmpeg->scaleByHeight(300, false);
+
+        $this->assertSame(['scale=trunc(oh/(ih/iw)/2)*2:if(gte(ih\,300)\,300\,ih)'], $this->getVideoFilter($ffmpeg));
+    }
+}


### PR DESCRIPTION
Resolves #96

- Updated `scaleByWidth` and `scaleByHeight` to include a `forceResize` parameter, allowing conditional resizing.
- Adjusted argument mapping in `Thumbnail\Processor` to support new parameter.


