### PR TITLE
Migrate Twig extensions to attributes (resolves #49)

### DIFF
--- a/bundles/CoreBundle/config/templating_twig.yaml
+++ b/bundles/CoreBundle/config/templating_twig.yaml
@@ -10,6 +10,7 @@ services:
     OpenDxp\Twig\Extension\HelpersExtension: ~
 
     OpenDxp\Twig\Extension\DocumentEditableExtension: ~
+    OpenDxp\Twig\Extension\DocumentEditableRenderExtension: ~
 
     OpenDxp\Twig\Extension\SubrequestExtension:
         lazy: true
@@ -81,4 +82,3 @@ services:
         arguments:
             $policy: '@OpenDxp\Twig\Sandbox\SecurityPolicy'
 
-    OpenDxp\Twig\Extension\AdminExtension: ~

--- a/doc/03_Documents/03_Navigation.md
+++ b/doc/03_Documents/03_Navigation.md
@@ -280,83 +280,62 @@ using Twig Extension.
 namespace App\Twig\Extension;
 
 use App\Website\LinkGenerator\NewsLinkGenerator;
-use App\Website\LinkGenerator\CategoryLinkGenerator; 
+use App\Website\LinkGenerator\CategoryLinkGenerator;
 use OpenDxp\Model\Document;
 use OpenDxp\Navigation\Container;
 use OpenDxp\Twig\Extension\Templating\Navigation;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
+use Twig\Attribute\AsTwigFunction;
 
-class NavigationExtension extends AbstractExtension
+class NavigationExtension
 {
-    protected Navigation $navigationHelper;
-    protected NewsLinkGenerator $newsLinkGenerator;
-    protected CategoryLinkGenerator $categoryLinkGenerator;
-
-    public function __construct(Navigation $navigationHelper, NewsLinkGenerator $newsLinkGenerator, CategoryLinkGenerator $categoryLinkGenerator)
-    {
-        $this->navigationHelper = $navigationHelper;
-        $this->newsLinkGenerator = $newsLinkGenerator;
-        $this->categoryLinkGenerator = $categoryLinkGenerator;
+    public function __construct(
+        private Navigation $navigationHelper,
+        private NewsLinkGenerator $newsLinkGenerator,
+        private CategoryLinkGenerator $categoryLinkGenerator,
+    ) {
     }
 
-    /**
-     * @return TwigFunction[]
-     */
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('app_navigation_links', [$this, 'getNavigationLinks'])
-        ];
-    }
-
-    /**
-     * @throws \Exception
-     */
+    #[AsTwigFunction('app_navigation_links')]
     public function getNavigationLinks(Document $document, Document $startNode): Container
     {
-        $navigation = $this->navigationHelper->build([
+        return $this->navigationHelper->build([
             'active' => $document,
             'root' => $startNode,
             'pageCallback' => function($page, $document) {
                 /** @var \OpenDxp\Model\Document $document */
                 /** @var \OpenDxp\Navigation\Page\Document $page */
-                if($document->getProperty("templateType") == "news") {
+                if ($document->getProperty('templateType') === 'news') {
                     $list = new \OpenDxp\Model\DataObject\News\Listing;
                     $list->load();
-                    foreach($list as $news) {
+                    foreach ($list as $news) {
                         $detailLink = $this->newsLinkGenerator->generate($news, ['document' => $document]);
-                        $uri = new \OpenDxp\Navigation\Page\Document([
-                            "label" => $news->getTitle(),
-                            "id" => "object-" . $news->getId(),
-                            "uri" => $detailLink,
-                        ]);
-                        $page->addPage($uri);
+                        $page->addPage(new \OpenDxp\Navigation\Page\Document([
+                            'label' => $news->getTitle(),
+                            'id' => 'object-' . $news->getId(),
+                            'uri' => $detailLink,
+                        ]));
                     }
                 }
             },
             'rootCallback' => function(Container $navigation) {
                 $list = new \OpenDxp\Model\DataObject\Category\Listing;
                 $list->load();
-                foreach($list as $category) {
+                foreach ($list as $category) {
                     $detailLink = $this->categoryLinkGenerator->generate($category);
-                    $categoryDocument = new \OpenDxp\Navigation\Page\Document([
-                        "label" => $category->getName(),
-                        "id" => "object-" . $category->getId(),
-                        "uri" => $detailLink,
-                    ]);
-                    $navigation->addPage($categoryDocument);
+                    $navigation->addPage(new \OpenDxp\Navigation\Page\Document([
+                        'label' => $category->getName(),
+                        'id' => 'object-' . $category->getId(),
+                        'uri' => $detailLink,
+                    ]));
                 }
-            }
+            },
         ]);
-
-        return $navigation;
     }
 }
 ```
 
 ```twig
-{% set navigation = app_navigation_news_links(document, navStartNode) %}
+{% set navigation = app_navigation_links(document, navStartNode) %}
 
 <div class="my-navigation">
     {{ opendxp_render_nav(navigation, 'menu', 'renderMenu', {
@@ -378,6 +357,7 @@ bypasses the caching mechanism of the navigation container.
 
 But sometimes it's necessary to get some properties or other data out of the documents in the navigation to build the navigation as it should be. 
 For that we've introduced a new parameter for the navigation extension, which acts as a callback and allows to map custom data onto the navigation page item.
+
 ```php
 <?php
 
@@ -386,48 +366,29 @@ namespace App\Twig\Extension;
 use OpenDxp\Model\Document;
 use OpenDxp\Navigation\Container;
 use OpenDxp\Twig\Extension\Templating\Navigation;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
+use Twig\Attribute\AsTwigFunction;
 
-class NavigationExtension extends AbstractExtension
+class NavigationExtension
 {
-    protected Navigation $navigationHelper;
+    public function __construct(private Navigation $navigationHelper)
+    {
+    }
 
-    public function __construct(Navigation $navigationHelper)
-    {
-        $this->navigationHelper = $navigationHelper;
-    }
-    
-    /**
-     * @return TwigFunction[]
-     */
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('app_navigation_custom', [$this, 'getCustomNavigation'])
-        ];
-    }
-    
-    /**
-     * @throws \Exception
-     */
+    #[AsTwigFunction('app_navigation_custom')]
     public function getCustomNavigation(Document $document, Document $startNode): Container
     {
-        $navigation = $this->navigationHelper->build([
+        return $this->navigationHelper->build([
             'active' => $document,
-            'root' => $startNode, 
+            'root' => $startNode,
             'pageCallback' => function ($page, $document) {
-                $page->setCustomSetting("myCustomProperty", $document->getProperty("myCustomProperty"));
-                $page->setCustomSetting("subListClass", $document->getProperty("subListClass"));
-                $page->setCustomSetting("title", $document->getTitle());
-                $page->setCustomSetting("headline", $document->getEditable("headline")->getData());
-            }]
-        );
-
-        return $navigation;
+                $page->setCustomSetting('myCustomProperty', $document->getProperty('myCustomProperty'));
+                $page->setCustomSetting('subListClass', $document->getProperty('subListClass'));
+                $page->setCustomSetting('title', $document->getTitle());
+                $page->setCustomSetting('headline', $document->getEditable('headline')->getData());
+            },
+        ]);
     }
 }
-
 ```
 
 ```twig
@@ -460,7 +421,7 @@ Using this method will dramatically improve the performance of your navigation.
 Sometimes it's necessary to manually set the key for the navigation cache. 
 
 ```twig
-{% opendxp_build_nav({active: document, root: navStartNode, cache: 'yourindividualkey'}) %}
+{% set nav = opendxp_build_nav({active: document, root: navStartNode, cache: 'yourindividualkey'}) %}
 ```
 
 ### Disabling the Navigation Cache
@@ -468,22 +429,19 @@ Sometimes it's necessary to manually set the key for the navigation cache.
 You can disable the navigation cache by setting the `cache` argument to `false`.
 
 ```twig
-{% opendxp_build_nav({active: document, root: navStartNode, cache: false}) %}
+{% set nav = opendxp_build_nav({active: document, root: navStartNode, cache: false}) %}
 ```
 
 ## FAQ
 
-**A document does not show up in the navigation. Why?**
-
+**A document does not show up in the navigation. Why?**  
 Please make sure that the documents and its parent documents are published and that the document itself as well as all its parents have a navigation name set. 
 Neither the document itself nor one of its parent documents may have activated **Exclude From Navigation** in their properties. (`Document properties -> System properties`)
 
-**Why is the navigation not appearing?**
-
+**Why is the navigation not appearing?**  
 See the above question. If none of the documents have a navigation title set the render function will simply return nothing.
 
-**Why is the homepage not appearing in the navigation?**
-
+**Why is the homepage not appearing in the navigation?**  
 The homepage will not appear in the navigation by default. You can add the homepage (and any other page) manually:
 
 ```twig
@@ -495,18 +453,20 @@ The homepage will not appear in the navigation by default. You can add the homep
 }) %}
 ```
 
-If you retrieve the **home** document (which always has the ID 1) you can also retrieve its navigation properties so that they can be edited from the OpenDXP admin interface like all the other documents.
+If you retrieve the **home** document (which always has the ID 1) you can also retrieve its navigation properties 
+so that they can be edited from the OpenDXP admin interface like all the other documents.
 
 ```twig
 {% set home = opendxp_document(1) %}
- 
- {# 
+
+{# 
     order: put it in front of all the others
     uri: path to homepage
     label: visible label
     title: tooltip text
     active: active state (boolean)
- #}
+#}
+
 {% do navigation.addPage({
     order: -1,
     uri: '/',

--- a/lib/Twig/Extension/AssetHelperExtensions.php
+++ b/lib/Twig/Extension/AssetHelperExtensions.php
@@ -18,28 +18,64 @@ declare(strict_types=1);
 namespace OpenDxp\Twig\Extension;
 
 use OpenDxp\Model\Asset;
-use Override;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigTest;
+use Twig\Attribute\AsTwigTest;
 
 /**
  * @internal
  */
-class AssetHelperExtensions extends AbstractExtension
+class AssetHelperExtensions
 {
-    #[Override]
-    public function getTests(): array
+    #[AsTwigTest('opendxp_asset')]
+    public function isAsset(mixed $object): bool
     {
-        return [
-            new TwigTest('opendxp_asset', static fn ($object) => $object instanceof Asset),
-            new TwigTest('opendxp_asset_archive', static fn ($object) => $object instanceof Asset\Archive),
-            new TwigTest('opendxp_asset_audio', static fn ($object) => $object instanceof Asset\Audio),
-            new TwigTest('opendxp_asset_document', static fn ($object) => $object instanceof Asset\Document),
-            new TwigTest('opendxp_asset_folder', static fn ($object) => $object instanceof Asset\Folder),
-            new TwigTest('opendxp_asset_image', static fn ($object) => $object instanceof Asset\Image),
-            new TwigTest('opendxp_asset_text', static fn ($object) => $object instanceof Asset\Text),
-            new TwigTest('opendxp_asset_unknown', static fn ($object) => $object instanceof Asset\Unknown),
-            new TwigTest('opendxp_asset_video', static fn ($object) => $object instanceof Asset\Video),
-        ];
+        return $object instanceof Asset;
+    }
+
+    #[AsTwigTest('opendxp_asset_archive')]
+    public function isAssetArchive(mixed $object): bool
+    {
+        return $object instanceof Asset\Archive;
+    }
+
+    #[AsTwigTest('opendxp_asset_audio')]
+    public function isAssetAudio(mixed $object): bool
+    {
+        return $object instanceof Asset\Audio;
+    }
+
+    #[AsTwigTest('opendxp_asset_document')]
+    public function isAssetDocument(mixed $object): bool
+    {
+        return $object instanceof Asset\Document;
+    }
+
+    #[AsTwigTest('opendxp_asset_folder')]
+    public function isAssetFolder(mixed $object): bool
+    {
+        return $object instanceof Asset\Folder;
+    }
+
+    #[AsTwigTest('opendxp_asset_image')]
+    public function isAssetImage(mixed $object): bool
+    {
+        return $object instanceof Asset\Image;
+    }
+
+    #[AsTwigTest('opendxp_asset_text')]
+    public function isAssetText(mixed $object): bool
+    {
+        return $object instanceof Asset\Text;
+    }
+
+    #[AsTwigTest('opendxp_asset_unknown')]
+    public function isAssetUnknown(mixed $object): bool
+    {
+        return $object instanceof Asset\Unknown;
+    }
+
+    #[AsTwigTest('opendxp_asset_video')]
+    public function isAssetVideo(mixed $object): bool
+    {
+        return $object instanceof Asset\Video;
     }
 }

--- a/lib/Twig/Extension/DataObjectHelperExtensions.php
+++ b/lib/Twig/Extension/DataObjectHelperExtensions.php
@@ -18,38 +18,50 @@ declare(strict_types=1);
 namespace OpenDxp\Twig\Extension;
 
 use OpenDxp\Model\DataObject;
-use Override;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
-use Twig\TwigTest;
+use Twig\Attribute\AsTwigFunction;
+use Twig\Attribute\AsTwigTest;
 
 /**
  * @internal
  */
-class DataObjectHelperExtensions extends AbstractExtension
+class DataObjectHelperExtensions
 {
-    #[Override]
-    public function getTests(): array
+    #[AsTwigTest('opendxp_data_object')]
+    public function isDataObject(mixed $object): bool
     {
-        return [
-            new TwigTest('opendxp_data_object', static fn ($object) => $object instanceof DataObject\Concrete),
-            new TwigTest('opendxp_data_object_folder', static fn ($object) => $object instanceof DataObject\Folder),
-            new TwigTest('opendxp_data_object_class', static function ($object, $className) {
-                $className = ucfirst($className);
-                $className = 'OpenDxp\\Model\\DataObject\\' . $className;
-
-                return class_exists($className) && $object instanceof $className;
-            }),
-            new TwigTest('opendxp_data_object_gallery', static fn ($object) => $object instanceof DataObject\Data\ImageGallery),
-            new TwigTest('opendxp_data_object_hotspot_image', static fn ($object) => $object instanceof DataObject\Data\Hotspotimage),
-        ];
+        return $object instanceof DataObject\Concrete;
     }
 
-    #[Override]
-    public function getFunctions(): array
+    #[AsTwigTest('opendxp_data_object_folder')]
+    public function isDataObjectFolder(mixed $object): bool
     {
-        return [
-            new TwigFunction('opendxp_data_object_select_options', static fn ($object, $field) => DataObject\Service::getOptionsForSelectField($object, $field)),
-        ];
+        return $object instanceof DataObject\Folder;
+    }
+
+    #[AsTwigTest('opendxp_data_object_class')]
+    public function isDataObjectClass(mixed $object, string $className): bool
+    {
+        $className = ucfirst($className);
+        $className = 'OpenDxp\\Model\\DataObject\\' . $className;
+
+        return class_exists($className) && $object instanceof $className;
+    }
+
+    #[AsTwigTest('opendxp_data_object_gallery')]
+    public function isDataObjectGallery(mixed $object): bool
+    {
+        return $object instanceof DataObject\Data\ImageGallery;
+    }
+
+    #[AsTwigTest('opendxp_data_object_hotspot_image')]
+    public function isDataObjectHotspotImage(mixed $object): bool
+    {
+        return $object instanceof DataObject\Data\Hotspotimage;
+    }
+
+    #[AsTwigFunction('opendxp_data_object_select_options')]
+    public function getDataObjectSelectOptions(mixed $object, string $field): array
+    {
+        return DataObject\Service::getOptionsForSelectField($object, $field);
     }
 }

--- a/lib/Twig/Extension/DocumentEditableExtension.php
+++ b/lib/Twig/Extension/DocumentEditableExtension.php
@@ -16,9 +16,7 @@ declare(strict_types=1);
 
 namespace OpenDxp\Twig\Extension;
 
-use Exception;
-use Generator;
-use OpenDxp\Model\Document\Editable\BlockInterface;
+use OpenDxp\Model\Document\Editable\EditableInterface;
 use OpenDxp\Model\Document\PageSnippet;
 use OpenDxp\Templating\Renderer\EditableRenderer;
 use OpenDxp\Twig\TokenParser\BlockParser;
@@ -28,6 +26,12 @@ use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 /**
+ * Registers the wildcard fallback `opendxp_*` for custom editables (e.g. from third-party bundles)
+ * and the token parsers.
+ *
+ * Built-in editable types are additionally registered with explicit signatures in DocumentEditableRenderExtension.
+ * Twig resolves exact matches before wildcards, so both coexist without conflict.
+ *
  * @internal
  */
 class DocumentEditableExtension extends AbstractExtension
@@ -44,58 +48,7 @@ class DocumentEditableExtension extends AbstractExtension
                 'needs_context' => true,
                 'is_safe' => ['html'],
             ]),
-            new TwigFunction('opendxp_iterate_block', $this->getBlockIterator(...)),
         ];
-
-        // @phpstan-ignore-next-line those are just for auto-complete, not nice, but works ;-)
-        new TwigFunction('opendxp_area');
-        new TwigFunction('opendxp_areablock');
-        new TwigFunction('opendxp_block');
-        new TwigFunction('opendxp_checkbox');
-        new TwigFunction('opendxp_date');
-        new TwigFunction('opendxp_embed');
-        new TwigFunction('opendxp_image');
-        new TwigFunction('opendxp_input');
-        new TwigFunction('opendxp_link');
-        new TwigFunction('opendxp_multiselect');
-        new TwigFunction('opendxp_numeric');
-        new TwigFunction('opendxp_pdf');
-        new TwigFunction('opendxp_relation');
-        new TwigFunction('opendxp_relations');
-        new TwigFunction('opendxp_renderlet');
-        new TwigFunction('opendxp_scheduledblock');
-        new TwigFunction('opendxp_select');
-        new TwigFunction('opendxp_snippet');
-        new TwigFunction('opendxp_table');
-        new TwigFunction('opendxp_textarea');
-        new TwigFunction('opendxp_video');
-        new TwigFunction('opendxp_wysiwyg');
-    }
-
-    /**
-     * @internal
-     *
-     * @throws Exception
-     */
-    public function renderEditable(array $context, string $type, string $name, array $options = []): string|\OpenDxp\Model\Document\Editable\EditableInterface
-    {
-        $document = $context['document'] ?? null;
-        if (!($document instanceof PageSnippet)) {
-            return '';
-        }
-        $editmode = $context['editmode'] ?? false;
-
-        return $this->editableRenderer->render($document, $type, $name, $options, $editmode);
-    }
-
-    /**
-     * Returns an iterator which can be used instead of while($block->loop())
-     *
-     * @internal
-     */
-    public function getBlockIterator(BlockInterface $block): Generator
-    {
-        return $block->getIterator();
     }
 
     #[Override]
@@ -105,5 +58,21 @@ class DocumentEditableExtension extends AbstractExtension
             new BlockParser(),
             new ManualBlockParser(),
         ];
+    }
+
+    public function renderEditable(array $context, string $type, string $name, array $options = []): string|EditableInterface
+    {
+        $document = $context['document'] ?? null;
+        if (!($document instanceof PageSnippet)) {
+            return '';
+        }
+
+        return $this->editableRenderer->render(
+            $document,
+            $type,
+            $name,
+            $options,
+            $context['editmode'] ?? false
+        );
     }
 }

--- a/lib/Twig/Extension/DocumentEditableRenderExtension.php
+++ b/lib/Twig/Extension/DocumentEditableRenderExtension.php
@@ -1,0 +1,188 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (https://pimcore.com)
+ * @copyright  Modification Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Twig\Extension;
+
+use Generator;
+use OpenDxp\Model\Document\Editable\BlockInterface;
+use OpenDxp\Model\Document\Editable\EditableInterface;
+use OpenDxp\Model\Document\PageSnippet;
+use OpenDxp\Templating\Renderer\EditableRenderer;
+use Twig\Attribute\AsTwigFunction;
+
+/**
+ * @internal
+ */
+class DocumentEditableRenderExtension
+{
+    public function __construct(protected EditableRenderer $editableRenderer)
+    {
+    }
+
+    #[AsTwigFunction('opendxp_area', needsContext: true, isSafe: ['html'])]
+    public function renderArea(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'area', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_areablock', needsContext: true, isSafe: ['html'])]
+    public function renderAreablock(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'areablock', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_block', needsContext: true, isSafe: ['html'])]
+    public function renderBlock(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'block', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_checkbox', needsContext: true, isSafe: ['html'])]
+    public function renderCheckbox(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'checkbox', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_date', needsContext: true, isSafe: ['html'])]
+    public function renderDate(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'date', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_embed', needsContext: true, isSafe: ['html'])]
+    public function renderEmbed(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'embed', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_image', needsContext: true, isSafe: ['html'])]
+    public function renderImage(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'image', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_input', needsContext: true, isSafe: ['html'])]
+    public function renderInput(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'input', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_link', needsContext: true, isSafe: ['html'])]
+    public function renderLink(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'link', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_multiselect', needsContext: true, isSafe: ['html'])]
+    public function renderMultiselect(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'multiselect', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_numeric', needsContext: true, isSafe: ['html'])]
+    public function renderNumeric(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'numeric', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_pdf', needsContext: true, isSafe: ['html'])]
+    public function renderPdf(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'pdf', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_relation', needsContext: true, isSafe: ['html'])]
+    public function renderRelation(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'relation', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_relations', needsContext: true, isSafe: ['html'])]
+    public function renderRelations(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'relations', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_renderlet', needsContext: true, isSafe: ['html'])]
+    public function renderRenderlet(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'renderlet', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_scheduledblock', needsContext: true, isSafe: ['html'])]
+    public function renderScheduledblock(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'scheduledblock', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_select', needsContext: true, isSafe: ['html'])]
+    public function renderSelect(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'select', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_snippet', needsContext: true, isSafe: ['html'])]
+    public function renderSnippet(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'snippet', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_table', needsContext: true, isSafe: ['html'])]
+    public function renderTable(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'table', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_textarea', needsContext: true, isSafe: ['html'])]
+    public function renderTextarea(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'textarea', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_video', needsContext: true, isSafe: ['html'])]
+    public function renderVideo(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'video', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_wysiwyg', needsContext: true, isSafe: ['html'])]
+    public function renderWysiwyg(array $context, string $name, array $options = []): string|EditableInterface
+    {
+        return $this->renderEditable($context, 'wysiwyg', $name, $options);
+    }
+
+    #[AsTwigFunction('opendxp_iterate_block')]
+    public function getBlockIterator(BlockInterface $block): Generator
+    {
+        return $block->getIterator();
+    }
+
+    private function renderEditable(array $context, string $type, string $name, array $options = []): string|EditableInterface
+    {
+        $document = $context['document'] ?? null;
+        if (!($document instanceof PageSnippet)) {
+            return '';
+        }
+
+        return $this->editableRenderer->render(
+            $document,
+            $type,
+            $name,
+            $options,
+            $context['editmode'] ?? false
+        );
+    }
+}

--- a/lib/Twig/Extension/DocumentHelperExtensions.php
+++ b/lib/Twig/Extension/DocumentHelperExtensions.php
@@ -18,27 +18,58 @@ declare(strict_types=1);
 namespace OpenDxp\Twig\Extension;
 
 use OpenDxp\Model\Document;
-use Override;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigTest;
+use Twig\Attribute\AsTwigTest;
 
 /**
  * @internal
  */
-class DocumentHelperExtensions extends AbstractExtension
+class DocumentHelperExtensions
 {
-    #[Override]
-    public function getTests(): array
+    #[AsTwigTest('opendxp_document')]
+    public function isDocument(mixed $object): bool
     {
-        return [
-            new TwigTest('opendxp_document', static fn ($object) => $object instanceof Document),
-            new TwigTest('opendxp_document_email', static fn ($object) => $object instanceof Document\Email),
-            new TwigTest('opendxp_document_folder', static fn ($object) => $object instanceof Document\Folder),
-            new TwigTest('opendxp_document_hardlink', static fn ($object) => $object instanceof Document\Hardlink),
-            new TwigTest('opendxp_document_page', static fn ($object) => $object instanceof Document\Page),
-            new TwigTest('opendxp_document_link', static fn ($object) => $object instanceof Document\Link),
-            new TwigTest('opendxp_document_page_snippet', static fn ($object) => $object instanceof Document\PageSnippet),
-            new TwigTest('opendxp_document_snippet', static fn ($object) => $object instanceof Document\Snippet),
-        ];
+        return $object instanceof Document;
+    }
+
+    #[AsTwigTest('opendxp_document_email')]
+    public function isDocumentEmail(mixed $object): bool
+    {
+        return $object instanceof Document\Email;
+    }
+
+    #[AsTwigTest('opendxp_document_folder')]
+    public function isDocumentFolder(mixed $object): bool
+    {
+        return $object instanceof Document\Folder;
+    }
+
+    #[AsTwigTest('opendxp_document_hardlink')]
+    public function isDocumentHardlink(mixed $object): bool
+    {
+        return $object instanceof Document\Hardlink;
+    }
+
+    #[AsTwigTest('opendxp_document_page')]
+    public function isDocumentPage(mixed $object): bool
+    {
+        return $object instanceof Document\Page;
+    }
+
+    #[AsTwigTest('opendxp_document_link')]
+    public function isDocumentLink(mixed $object): bool
+    {
+        return $object instanceof Document\Link;
+    }
+
+    #[AsTwigTest('opendxp_document_page_snippet')]
+    public function isDocumentPageSnippet(mixed $object): bool
+    {
+        return $object instanceof Document\PageSnippet;
+    }
+
+    #[AsTwigTest('opendxp_document_snippet')]
+    public function isDocumentSnippet(mixed $object): bool
+    {
+        return $object instanceof Document\Snippet;
     }
 }

--- a/lib/Twig/Extension/HeaderExtension.php
+++ b/lib/Twig/Extension/HeaderExtension.php
@@ -24,56 +24,64 @@ use OpenDxp\Twig\Extension\Templating\HeadStyle;
 use OpenDxp\Twig\Extension\Templating\HeadTitle;
 use OpenDxp\Twig\Extension\Templating\InlineScript;
 use OpenDxp\Twig\Extension\Templating\Placeholder;
-use Override;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
+use OpenDxp\Twig\Extension\Templating\Placeholder\Container;
+use Twig\Attribute\AsTwigFunction;
 
 /**
  * @internal
  */
-class HeaderExtension extends AbstractExtension
+class HeaderExtension
 {
-    private readonly HeadLink $headLink;
-
-    private readonly HeadMeta $headMeta;
-
-    private readonly HeadScript $headScript;
-
-    private readonly HeadStyle $headStyle;
-
-    private readonly HeadTitle $headTitle;
-
-    private readonly InlineScript $inlineScript;
-
-    private readonly Placeholder $placeholder;
-
-    public function __construct(HeadLink $headLink, HeadMeta $headMeta, HeadScript $headScript, HeadStyle $headStyle, HeadTitle $headTitle, InlineScript $inlineScript, Placeholder $placeholder)
-    {
-        $this->headLink = $headLink;
-        $this->headMeta = $headMeta;
-        $this->headScript = $headScript;
-        $this->headStyle = $headStyle;
-        $this->headTitle = $headTitle;
-        $this->inlineScript = $inlineScript;
-        $this->placeholder = $placeholder;
+    public function __construct(
+        private readonly HeadLink $headLink,
+        private readonly HeadMeta $headMeta,
+        private readonly HeadScript $headScript,
+        private readonly HeadStyle $headStyle,
+        private readonly HeadTitle $headTitle,
+        private readonly InlineScript $inlineScript,
+        private readonly Placeholder $placeholder
+    ) {
     }
 
-    #[Override]
-    public function getFunctions(): array
+    #[AsTwigFunction('opendxp_head_link', isSafe: ['html'])]
+    public function renderHeadLink(?array $attributes = null, string $placement = Container::APPEND): HeadLink
     {
-        $options = [
-            'is_safe' => ['html'],
-        ];
+        return ($this->headLink)($attributes, $placement);
+    }
 
-        // as runtime extension classes are invokable, we can pass them directly as callable
-        return [
-            new TwigFunction('opendxp_head_link', $this->headLink, $options),
-            new TwigFunction('opendxp_head_meta', $this->headMeta, $options),
-            new TwigFunction('opendxp_head_script', $this->headScript, $options),
-            new TwigFunction('opendxp_head_style', $this->headStyle, $options),
-            new TwigFunction('opendxp_head_title', $this->headTitle, $options),
-            new TwigFunction('opendxp_inline_script', $this->inlineScript, $options),
-            new TwigFunction('opendxp_placeholder', $this->placeholder, $options),
-        ];
+    #[AsTwigFunction('opendxp_head_meta', isSafe: ['html'])]
+    public function renderHeadMeta(?string $content = null, ?string $keyValue = null, string $keyType = 'name', array $modifiers = [], string $placement = Container::APPEND): HeadMeta
+    {
+        return ($this->headMeta)($content, $keyValue, $keyType, $modifiers, $placement);
+    }
+
+    #[AsTwigFunction('opendxp_head_script', isSafe: ['html'])]
+    public function renderHeadScript(string $mode = HeadScript::FILE, ?string $spec = null, string $placement = 'APPEND', array $attrs = [], string $type = 'text/javascript'): HeadScript
+    {
+        return ($this->headScript)($mode, $spec, $placement, $attrs, $type);
+    }
+
+    #[AsTwigFunction('opendxp_head_style', isSafe: ['html'])]
+    public function renderHeadStyle(?string $content = null, string $placement = 'APPEND', array|string $attributes = []): HeadStyle
+    {
+        return ($this->headStyle)($content, $placement, $attributes);
+    }
+
+    #[AsTwigFunction('opendxp_head_title', isSafe: ['html'])]
+    public function renderHeadTitle(?string $title = null, ?string $setType = null): HeadTitle
+    {
+        return ($this->headTitle)($title, $setType);
+    }
+
+    #[AsTwigFunction('opendxp_inline_script', isSafe: ['html'])]
+    public function renderInlineScript(string $mode = HeadScript::FILE, ?string $spec = null, string $placement = 'APPEND', array $attrs = [], string $type = 'text/javascript'): InlineScript
+    {
+        return ($this->inlineScript)($mode, $spec, $placement, $attrs, $type);
+    }
+
+    #[AsTwigFunction('opendxp_placeholder', isSafe: ['html'])]
+    public function renderPlaceholder(?string $containerName = null): Container
+    {
+        return ($this->placeholder)($containerName);
     }
 }

--- a/lib/Twig/Extension/HelpersExtension.php
+++ b/lib/Twig/Extension/HelpersExtension.php
@@ -21,69 +21,54 @@ use Exception;
 use OpenDxp\Document;
 use OpenDxp\Twig\Extension\Templating\OpenDxpUrl;
 use OpenDxp\Video;
-use Override;
 use Symfony\Component\Mime\MimeTypes;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFilter;
-use Twig\TwigFunction;
-use Twig\TwigTest;
+use Twig\Attribute\AsTwigFilter;
+use Twig\Attribute\AsTwigFunction;
+use Twig\Attribute\AsTwigTest;
 
 /**
  * @internal
  */
-class HelpersExtension extends AbstractExtension
+class HelpersExtension
 {
-    private readonly OpenDxpUrl $OpenDxpUrlHelper;
-
-    public function __construct(OpenDxpUrl $OpenDxpUrlHelper)
+    public function __construct(private readonly OpenDxpUrl $OpenDxpUrlHelper)
     {
-        $this->OpenDxpUrlHelper = $OpenDxpUrlHelper;
     }
 
-    #[Override]
-    public function getFilters(): array
-    {
-        return [
-            new TwigFilter('basename', $this->basenameFilter(...)),
-        ];
-    }
-
-    #[Override]
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('opendxp_video_is_available', Video::isAvailable(...)),
-            new TwigFunction('opendxp_document_is_available', Document::isAvailable(...)),
-            new TwigFunction('opendxp_file_exists', is_file(...)),
-            new TwigFunction('opendxp_file_extension', $this->getFileExtension(...)),
-            new TwigFunction('opendxp_image_version_preview', $this->getImageVersionPreview(...)),
-            new TwigFunction('opendxp_asset_version_preview', $this->getAssetVersionPreview(...)),
-            new TwigFunction('opendxp_breach_attack_random_content', $this->breachAttackRandomContent(...), [
-                'is_safe' => ['html'],
-            ]),
-            new TwigFunction('opendxp_url', $this->OpenDxpUrlHelper, [
-                'name' => 'opendxp_url',
-                'is_safe' => null,
-            ]),
-        ];
-    }
-
-    #[Override]
-    public function getTests(): array
-    {
-        return [
-            new TwigTest('instanceof', fn ($object, $class) => $object instanceof $class),
-        ];
-    }
-
+    #[AsTwigFilter('basename')]
     public function basenameFilter(string $value, string $suffix = ''): string
     {
         return basename($value, $suffix);
     }
 
+    #[AsTwigFunction('opendxp_video_is_available')]
+    public function isVideoAvailable(): bool
+    {
+        return Video::isAvailable();
+    }
+
+    #[AsTwigFunction('opendxp_document_is_available')]
+    public function isDocumentAvailable(): bool
+    {
+        return Document::isAvailable();
+    }
+
+    #[AsTwigFunction('opendxp_file_exists')]
+    public function fileExists(string $path): bool
+    {
+        return is_file($path);
+    }
+
+    #[AsTwigFunction('opendxp_file_extension')]
+    public function getFileExtension(string $fileName): string
+    {
+        return pathinfo($fileName, PATHINFO_EXTENSION);
+    }
+
     /**
      * @throws Exception
      */
+    #[AsTwigFunction('opendxp_image_version_preview')]
     public function getImageVersionPreview(string $file): string
     {
         $thumbnail = OPENDXP_SYSTEM_TEMP_DIRECTORY . '/image-version-preview-' . uniqid() . '.png';
@@ -102,6 +87,7 @@ class HelpersExtension extends AbstractExtension
     /**
      * @throws Exception
      */
+    #[AsTwigFunction('opendxp_asset_version_preview')]
     public function getAssetVersionPreview(string $file): string
     {
         $dataUri = 'data:'.MimeTypes::getDefault()->guessMimeType($file).';base64,'.base64_encode(file_get_contents($file));
@@ -113,6 +99,7 @@ class HelpersExtension extends AbstractExtension
     /**
      * @throws Exception
      */
+    #[AsTwigFunction('opendxp_breach_attack_random_content', isSafe: ['html'])]
     public function breachAttackRandomContent(): string
     {
         $length = 50;
@@ -127,8 +114,15 @@ class HelpersExtension extends AbstractExtension
             . '-->';
     }
 
-    public function getFileExtension(string $fileName): string
+    #[AsTwigFunction('opendxp_url')]
+    public function opendxpUrl(array $urlOptions = [], ?string $name = null, bool $reset = false, bool $encode = true, bool $relative = false): string
     {
-        return pathinfo($fileName, PATHINFO_EXTENSION);
+        return ($this->OpenDxpUrlHelper)($urlOptions, $name, $reset, $encode, $relative);
+    }
+
+    #[AsTwigTest('instanceof')]
+    public function isInstanceOf(mixed $object, string $class): bool
+    {
+        return $object instanceof $class;
     }
 }

--- a/lib/Twig/Extension/NavigationExtension.php
+++ b/lib/Twig/Extension/NavigationExtension.php
@@ -17,29 +17,35 @@ declare(strict_types=1);
 
 namespace OpenDxp\Twig\Extension;
 
+use OpenDxp\Navigation\Container;
+use OpenDxp\Navigation\Renderer\RendererInterface;
 use OpenDxp\Twig\Extension\Templating\Navigation;
-use Override;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
+use Twig\Attribute\AsTwigFunction;
 
 /**
  * @internal
  */
-class NavigationExtension extends AbstractExtension
+class NavigationExtension
 {
     public function __construct(private readonly Navigation $navigationExtension)
     {
     }
 
-    #[Override]
-    public function getFunctions(): array
+    #[AsTwigFunction('opendxp_build_nav')]
+    public function buildNav(array $params): Container
     {
-        return [
-            new TwigFunction('opendxp_build_nav', $this->navigationExtension->build(...)),
-            new TwigFunction('opendxp_render_nav', $this->navigationExtension->render(...), [
-                'is_safe' => ['html'],
-            ]),
-            new TwigFunction('opendxp_nav_renderer', $this->navigationExtension->getRenderer(...)),
-        ];
+        return $this->navigationExtension->build($params);
+    }
+
+    #[AsTwigFunction('opendxp_render_nav', isSafe: ['html'])]
+    public function renderNav(Container $container, string $rendererName = 'menu', string $renderMethod = 'render', mixed ...$rendererArguments): string
+    {
+        return $this->navigationExtension->render($container, $rendererName, $renderMethod, ...$rendererArguments);
+    }
+
+    #[AsTwigFunction('opendxp_nav_renderer')]
+    public function getNavRenderer(string $alias): RendererInterface
+    {
+        return $this->navigationExtension->getRenderer($alias);
     }
 }

--- a/lib/Twig/Extension/OpenDxpObjectExtension.php
+++ b/lib/Twig/Extension/OpenDxpObjectExtension.php
@@ -20,42 +20,104 @@ namespace OpenDxp\Twig\Extension;
 use OpenDxp\Helper\StringHelper;
 use OpenDxp\Model\Asset;
 use OpenDxp\Model\DataObject;
+use OpenDxp\Model\DataObject\Classificationstore\GroupConfig;
+use OpenDxp\Model\DataObject\Objectbrick\Definition;
 use OpenDxp\Model\Document;
+use OpenDxp\Model\Document\Hardlink\Wrapper;
 use OpenDxp\Model\Site;
 use OpenDxp\Model\User;
-use Override;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
+use Twig\Attribute\AsTwigFunction;
 
 /**
  * @internal
  */
-class OpenDxpObjectExtension extends AbstractExtension
+class OpenDxpObjectExtension
 {
-    #[Override]
-    public function getFunctions(): array
+    #[AsTwigFunction('opendxp_document')]
+    public function getDocument(int $id, array $params = []): ?Document
     {
-        // simple object access functions in case documents/assets/objects need to be loaded directly in the template
-        return [
-            new TwigFunction('opendxp_document', Document::getById(...)),
-            new TwigFunction('opendxp_document_by_path', Document::getByPath(...)),
-            new TwigFunction('opendxp_site', Site::getById(...)),
-            new TwigFunction('opendxp_site_by_root_id', Site::getByRootId(...)),
-            new TwigFunction('opendxp_site_by_domain', Site::getByDomain(...)),
-            new TwigFunction('opendxp_site_is_request', Site::isSiteRequest(...)),
-            new TwigFunction('opendxp_site_current', Site::getCurrentSite(...)),
-            new TwigFunction('opendxp_asset', Asset::getById(...)),
-            new TwigFunction('opendxp_asset_by_path', Asset::getByPath(...)),
-            new TwigFunction('opendxp_object', DataObject::getById(...)),
-            new TwigFunction('opendxp_object_by_path', DataObject::getByPath(...)),
-            new TwigFunction('opendxp_document_wrap_hardlink', Document\Hardlink\Service::wrap(...)),
-            new TwigFunction('opendxp_user', User::getById(...)),
-            new TwigFunction('opendxp_object_classificationstore_group', DataObject\Classificationstore\GroupConfig::getById(...)),
-            new TwigFunction('opendxp_object_classificationstore_get_field_definition_from_json', $this->getFieldDefinitionFromJson(...)),
-            new TwigFunction('opendxp_object_brick_definition_key', DataObject\Objectbrick\Definition::getByKey(...)),
-        ];
+        return Document::getById($id, $params);
     }
 
+    #[AsTwigFunction('opendxp_document_by_path')]
+    public function getDocumentByPath(string $path, array $params = []): ?Document
+    {
+        return Document::getByPath($path, $params);
+    }
+
+    #[AsTwigFunction('opendxp_site')]
+    public function getSite(int $id): ?Site
+    {
+        return Site::getById($id);
+    }
+
+    #[AsTwigFunction('opendxp_site_by_root_id')]
+    public function getSiteByRootId(int $id): ?Site
+    {
+        return Site::getByRootId($id);
+    }
+
+    #[AsTwigFunction('opendxp_site_by_domain')]
+    public function getSiteByDomain(string $domain): ?Site
+    {
+        return Site::getByDomain($domain);
+    }
+
+    #[AsTwigFunction('opendxp_site_is_request')]
+    public function isSiteRequest(): bool
+    {
+        return Site::isSiteRequest();
+    }
+
+    #[AsTwigFunction('opendxp_site_current')]
+    public function getCurrentSite(): Site
+    {
+        return Site::getCurrentSite();
+    }
+
+    #[AsTwigFunction('opendxp_asset')]
+    public function getAsset(int $id, array $params = []): ?Asset
+    {
+        return Asset::getById($id, $params);
+    }
+
+    #[AsTwigFunction('opendxp_asset_by_path')]
+    public function getAssetByPath(string $path, array $params = []): ?Asset
+    {
+        return Asset::getByPath($path, $params);
+    }
+
+    #[AsTwigFunction('opendxp_object')]
+    public function getDataObject(int $id, array $params = []): ?DataObject\AbstractObject
+    {
+        return DataObject::getById($id, $params);
+    }
+
+    #[AsTwigFunction('opendxp_object_by_path')]
+    public function getDataObjectByPath(string $path, array $params = []): ?DataObject\AbstractObject
+    {
+        return DataObject::getByPath($path, $params);
+    }
+
+    #[AsTwigFunction('opendxp_document_wrap_hardlink')]
+    public function wrapHardlink(Document $doc): Wrapper\WrapperInterface|Wrapper\Hardlink|null
+    {
+        return Document\Hardlink\Service::wrap($doc);
+    }
+
+    #[AsTwigFunction('opendxp_user')]
+    public function getUser(int $id): ?User
+    {
+        return User::getById($id);
+    }
+
+    #[AsTwigFunction('opendxp_object_classificationstore_group')]
+    public function getClassificationstoreGroup(int $id, ?bool $force = false): ?GroupConfig
+    {
+        return GroupConfig::getById($id, $force);
+    }
+
+    #[AsTwigFunction('opendxp_object_classificationstore_get_field_definition_from_json')]
     public function getFieldDefinitionFromJson(array|string $definition, string $type): ?DataObject\ClassDefinition\Data
     {
         if (StringHelper::isValidJson($definition)) {
@@ -63,5 +125,11 @@ class OpenDxpObjectExtension extends AbstractExtension
         }
 
         return DataObject\Classificationstore\Service::getFieldDefinitionFromJson($definition, $type);
+    }
+
+    #[AsTwigFunction('opendxp_object_brick_definition_key')]
+    public function getObjectbrickDefinitionByKey(string $key): ?Definition
+    {
+        return Definition::getByKey($key);
     }
 }

--- a/lib/Twig/Extension/OpenDxpToolExtension.php
+++ b/lib/Twig/Extension/OpenDxpToolExtension.php
@@ -17,22 +17,24 @@ declare(strict_types=1);
 
 namespace OpenDxp\Twig\Extension;
 
+use OpenDxp\Tool;
 use OpenDxp\Tool\DeviceDetector;
-use Override;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
+use Twig\Attribute\AsTwigFunction;
 
 /**
  * @internal
  */
-class OpenDxpToolExtension extends AbstractExtension
+class OpenDxpToolExtension
 {
-    #[Override]
-    public function getFunctions(): array
+    #[AsTwigFunction('opendxp_supported_locales')]
+    public function getSupportedLocales(): array
     {
-        return [
-            new TwigFunction('opendxp_supported_locales', \OpenDxp\Tool::getSupportedLocales(...)),
-            new TwigFunction('opendxp_device', DeviceDetector::getInstance(...), ['is_safe' => ['html']]),
-        ];
+        return Tool::getSupportedLocales();
+    }
+
+    #[AsTwigFunction('opendxp_device', isSafe: ['html'])]
+    public function getDevice(?string $default = null): DeviceDetector
+    {
+        return DeviceDetector::getInstance($default);
     }
 }

--- a/lib/Twig/Extension/SubrequestExtension.php
+++ b/lib/Twig/Extension/SubrequestExtension.php
@@ -16,31 +16,22 @@ declare(strict_types=1);
 
 namespace OpenDxp\Twig\Extension;
 
+use OpenDxp\Model\Document\PageSnippet;
 use OpenDxp\Twig\Extension\Templating\Inc;
-use Override;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
+use Twig\Attribute\AsTwigFunction;
 
 /**
  * @internal
  */
-class SubrequestExtension extends AbstractExtension
+class SubrequestExtension
 {
-    protected Inc $incHelper;
-
-    public function __construct(Inc $incHelper)
+    public function __construct(protected Inc $incHelper)
     {
-        $this->incHelper = $incHelper;
     }
 
-    #[Override]
-    public function getFunctions(): array
+    #[AsTwigFunction('opendxp_inc', isSafe: ['html'])]
+    public function inc(int|string|PageSnippet $include, array $params = [], bool $cacheEnabled = true, ?bool $editmode = null): string
     {
-        // as runtime extension classes are invokable, we can pass them directly as callable
-        return [
-            new TwigFunction('opendxp_inc', $this->incHelper, [
-                'is_safe' => ['html'],
-            ]),
-        ];
+        return ($this->incHelper)($include, $params, $cacheEnabled, $editmode);
     }
 }

--- a/rector.dist.php
+++ b/rector.dist.php
@@ -8,15 +8,13 @@ use Rector\CodeQuality\Rector\Foreach_\ForeachItemsAssignToEmptyArrayToAssignRec
 use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
 use Rector\CodingStyle\Rector\FuncCall\ArraySpreadInsteadOfArrayMergeRector;
 use Rector\Config\RectorConfig;
-use Rector\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector;
 use Rector\EarlyReturn\Rector\StmtsAwareInterface\ReturnEarlyIfVariableRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
+use Rector\Symfony\Symfony73\Rector\Class_\GetFunctionsToAsTwigFunctionAttributeRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\DataProviderArrayItemsNewLinedRector;
 use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
-use Rector\Symfony\Symfony73\Rector\Class_\GetFunctionsToAsTwigFunctionAttributeRector;
-use Rector\Symfony\Symfony73\Rector\Class_\GetFiltersToAsTwigFilterAttributeRector;
 use Rector\ValueObject\PhpVersion;
 
 return RectorConfig::configure()
@@ -32,18 +30,8 @@ return RectorConfig::configure()
         ReturnEarlyIfVariableRector::class                     => [
             __DIR__ . '/lib/Navigation/Page/Document.php',
         ],
-        RemoveUnreachableStatementRector::class                => [
-            __DIR__ . '/lib/Twig/Extension/DocumentEditableExtension.php',
-        ],
         GetFunctionsToAsTwigFunctionAttributeRector::class     => [
             __DIR__ . '/lib/Twig/Extension/DocumentEditableExtension.php',
-            __DIR__ . '/lib/Twig/Extension/HelpersExtension.php',
-            __DIR__ . '/lib/Twig/Extension/OpenDxpObjectExtension.php',
-        ],
-        GetFiltersToAsTwigFilterAttributeRector::class         => [
-            __DIR__ . '/lib/Twig/Extension/DocumentEditableExtension.php',
-            __DIR__ . '/lib/Twig/Extension/HelpersExtension.php',
-            __DIR__ . '/lib/Twig/Extension/OpenDxpObjectExtension.php',
         ],
         ClassPropertyAssignToConstructorPromotionRector::class => [
             __DIR__ . '/models/Version/Adapter/ProxyVersionStorageAdapter.php',


### PR DESCRIPTION
- Replaced `getFunctions` and `getTests` methods with `AsTwigFunction` and `AsTwigTest` attributes.
- Introduced the new `DocumentEditableRenderExtension` for builtin editable types.
- Refactored extensions for improved readability and maintainability, removing redundant or outdated implementations.