### PR TITLE
[Feature]: Add an OpenDXP SVG Version Badge

### DIFF
--- a/bundles/CoreBundle/config/routing.yaml
+++ b/bundles/CoreBundle/config/routing.yaml
@@ -2,6 +2,10 @@ _opendxp_service_robots_txt:
     path: /robots.txt
     defaults: { _controller: OpenDxp\Bundle\CoreBundle\Controller\PublicServicesController::robotsTxtAction }
 
+_opendxp_service_version_badge:
+    path: /version-badge
+    defaults: { _controller: OpenDxp\Bundle\CoreBundle\Controller\PublicServicesController::versionAction }
+
 _opendxp_service_common_files:
     path: /{filename}
     defaults: { _controller: OpenDxp\Bundle\CoreBundle\Controller\PublicServicesController::commonFilesAction }

--- a/bundles/CoreBundle/src/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/src/Controller/PublicServicesController.php
@@ -105,39 +105,9 @@ class PublicServicesController extends AbstractController
 
     public function versionAction(Request $request): Response
     {
-        $version = htmlspecialchars(\OpenDxp\Version::getVersion(), ENT_QUOTES, 'UTF-8');
-
-        $svg = <<<SVG
-            <svg xmlns="http://www.w3.org/2000/svg" width="73" height="18" role="img" aria-label="{$version}">
-                <title>{$version}</title>
-                <filter id="blur">
-                    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-                </filter>
-                <linearGradient id="s" x2="0" y2="100%">
-                    <stop offset="0" stop-color="#fff" stop-opacity=".7" />
-                    <stop offset=".1" stop-color="#aaa" stop-opacity=".1" />
-                    <stop offset=".9" stop-color="#000" stop-opacity=".3" />
-                    <stop offset="1" stop-color="#000" stop-opacity=".5" />
-                </linearGradient>
-                <clipPath id="r">
-                    <rect width="73" height="18" rx="4" fill="#fff" />
-                </clipPath>
-                <g clip-path="url(#r)">
-                    <rect width="18" height="18" fill="#DBFF00" />
-                    <circle cx="9" cy="9" r="4.378" fill="black"/>
-                    <rect x="18" width="55" height="18" fill="#555" />
-                    <rect width="73" height="18" fill="url(#s)" />
-                </g>
-                <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif"
-                    text-rendering="geometricPrecision" font-size="110">
-                    <text aria-hidden="true" x="459" y="140" fill="#010101" fill-opacity=".80"
-                        filter="url(#blur)" transform="scale(.1)">{$version}</text>
-                    <text aria-hidden="true" x="459" y="140" fill="#010101" fill-opacity=".3"
-                        transform="scale(.1)">{$version}</text>
-                    <text x="459" y="130" transform="scale(.1)" fill="#fff">{$version}</text>
-                </g>
-            </svg>
-            SVG;
+        $svg = $this->renderView('@OpenDxpCore/version_badge.svg.twig', [
+            'version' => \OpenDxp\Version::getVersion(),
+        ]);
 
         return new Response($svg, Response::HTTP_OK, [
             'Content-Type' => 'image/svg+xml',

--- a/bundles/CoreBundle/src/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/src/Controller/PublicServicesController.php
@@ -103,6 +103,47 @@ class PublicServicesController extends AbstractController
         return new Response("HTTP/1.1 404 Not Found\nFiltered by common files filter", 404);
     }
 
+    public function versionAction(Request $request): Response
+    {
+        $version = htmlspecialchars(\OpenDxp\Version::getVersion(), ENT_QUOTES, 'UTF-8');
+
+        $svg = <<<SVG
+            <svg xmlns="http://www.w3.org/2000/svg" width="73" height="18" role="img" aria-label="{$version}">
+                <title>{$version}</title>
+                <filter id="blur">
+                    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
+                </filter>
+                <linearGradient id="s" x2="0" y2="100%">
+                    <stop offset="0" stop-color="#fff" stop-opacity=".7" />
+                    <stop offset=".1" stop-color="#aaa" stop-opacity=".1" />
+                    <stop offset=".9" stop-color="#000" stop-opacity=".3" />
+                    <stop offset="1" stop-color="#000" stop-opacity=".5" />
+                </linearGradient>
+                <clipPath id="r">
+                    <rect width="73" height="18" rx="4" fill="#fff" />
+                </clipPath>
+                <g clip-path="url(#r)">
+                    <rect width="18" height="18" fill="#DBFF00" />
+                    <circle cx="9" cy="9" r="4.378" fill="black"/>
+                    <rect x="18" width="55" height="18" fill="#555" />
+                    <rect width="73" height="18" fill="url(#s)" />
+                </g>
+                <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif"
+                    text-rendering="geometricPrecision" font-size="110">
+                    <text aria-hidden="true" x="459" y="140" fill="#010101" fill-opacity=".80"
+                        filter="url(#blur)" transform="scale(.1)">{$version}</text>
+                    <text aria-hidden="true" x="459" y="140" fill="#010101" fill-opacity=".3"
+                        transform="scale(.1)">{$version}</text>
+                    <text x="459" y="130" transform="scale(.1)" fill="#fff">{$version}</text>
+                </g>
+            </svg>
+            SVG;
+
+        return new Response($svg, Response::HTTP_OK, [
+            'Content-Type' => 'image/svg+xml',
+        ]);
+    }
+
     public function customAdminEntryPointAction(Request $request): RedirectResponse
     {
         $params = $request->query->all();

--- a/bundles/CoreBundle/templates/version_badge.svg.twig
+++ b/bundles/CoreBundle/templates/version_badge.svg.twig
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="73" height="18" role="img" aria-label="{{ version }}">
+    <title>{{ version }}</title>
+    <filter id="blur">
+        <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
+    </filter>
+    <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#fff" stop-opacity=".7" />
+        <stop offset=".1" stop-color="#aaa" stop-opacity=".1" />
+        <stop offset=".9" stop-color="#000" stop-opacity=".3" />
+        <stop offset="1" stop-color="#000" stop-opacity=".5" />
+    </linearGradient>
+    <clipPath id="r">
+        <rect width="73" height="18" rx="4" fill="#fff" />
+    </clipPath>
+    <g clip-path="url(#r)">
+        <rect width="18" height="18" fill="#DBFF00" />
+        <circle cx="9" cy="9" r="4.378" fill="black"/>
+        <rect x="18" width="55" height="18" fill="#555" />
+        <rect width="73" height="18" fill="url(#s)" />
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif"
+        text-rendering="geometricPrecision" font-size="110">
+        <text aria-hidden="true" x="459" y="140" fill="#010101" fill-opacity=".80"
+            filter="url(#blur)" transform="scale(.1)">{{ version }}</text>
+        <text aria-hidden="true" x="459" y="140" fill="#010101" fill-opacity=".3"
+            transform="scale(.1)">{{ version }}</text>
+        <text x="459" y="130" transform="scale(.1)" fill="#fff">{{ version }}</text>
+    </g>
+</svg>


### PR DESCRIPTION
- [x] I have read and accepted the [CLA guidelines](/CLA.md).
- [ ] Features are properly documented in the `doc/` folder.

## Why this PR?
I wanted to have an at a glance overview about all our OpenDXP projects and their respective versions.

## Changes in this pull request  
This PR adds an SVG version badge accessible under the route /version-badge to the core bundle which shows the currently used version of OpenDXP.

The Version Badge looks like this (example):
<img width="73" height="18" alt="opendxp" src="https://github.com/user-attachments/assets/68739956-be0d-481a-8fb1-bfa000266eb7" />

### What is can it be used for?
- Useful to add a badge to your projects Github Readme to show the current Version at a glance.
- Useful for dashboards showing multiple OpenDXP Projects wanting to display the current versions.

## Additional info
- **Security considerations:** Maybe some people do not want to expose their used Version like this?
  - Option A: Add docs explaining how to remove the route.
  - Option B: The route is commented out by default, add docs to explain how to enable the badge.
  - Option C: Add rudimentary protection by adding a query param to the route with some sort of "secret".
  - Option D: ... ideas welcome
 
 @solverat  What's your opinion on this? Let me know if this is something useful and if i should change something or add docs (wanted to wait until an option in security considerations is choosen).