### PR TITLE
[Chore]: Fix infinite-loop typo and stale routing docblock

### DIFF
--- a/bundles/CoreBundle/src/DependencyInjection/Compiler/RoutingLoaderPass.php
+++ b/bundles/CoreBundle/src/DependencyInjection/Compiler/RoutingLoaderPass.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Set attribute loader to our own implementation normalizing admin routes: converts the prefix
- * opendxp_pimcoreadmin_ to just opendxp_admin_
+ * opendxp_admin_admin_ to just opendxp_admin_
  *
  * @internal
  */

--- a/lib/SystemSettingsConfig.php
+++ b/lib/SystemSettingsConfig.php
@@ -227,7 +227,7 @@ class SystemSettingsConfig
                 $target = trim($l);
                 if ($target) {
                     if (in_array($target, $fallbacks)) {
-                        throw new Exception("Language `$source` | `$target` causes an infinte loop.");
+                        throw new Exception("Language `$source` | `$target` causes an infinite loop.");
                     }
                     $fallbacks[] = $target;
 


### PR DESCRIPTION
## Changes in this pull request
Two small non-functional fixes.

**1. `lib/SystemSettingsConfig.php` — typo in exception message** "infinte loop" → "infinite loop".

**2. `RoutingLoaderPass.php` — stale docblock**
The [docblock](https://github.com/open-dxp/opendxp/blob/c7e1c656302deac3cffde552ba25b3821d152393/bundles/CoreBundle/src/DependencyInjection/Compiler/RoutingLoaderPass.php#L25) says the loader converts prefix `opendxp_pimcoreadmin_` to `opendxp_admin_`. That token exists nowhere in the codebase. The loader ([AttributeRouteControllerLoader](https://github.com/open-dxp/opendxp/blob/c7e1c656302deac3cffde552ba25b3821d152393/lib/Routing/Loader/AttributeRouteControllerLoader.php#L37)) actually collapses `opendxp_admin_admin_` to `opendxp_admin_`. Comment corrected to match.
