### PR TITLE
Make thumbnail generation errors in PublicServicesController more actionable by logging additional information

### DIFF
--- a/bundles/CoreBundle/src/Controller/PublicServicesController.php
+++ b/bundles/CoreBundle/src/Controller/PublicServicesController.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace OpenDxp\Bundle\CoreBundle\Controller;
 
 use Exception;
+use League\Flysystem\FilesystemException;
 use OpenDxp\Bundle\SeoBundle\Config;
 use OpenDxp\Logger;
 use OpenDxp\Model\Asset;
@@ -54,11 +55,18 @@ class PublicServicesController extends AbstractController
             }
 
             throw new Exception('Unable to generate '.$config['type'].' thumbnail, see logs for details.');
-        } catch (Exception $e) {
-            Logger::error($e->getMessage());
-
-            return new RedirectResponse('/bundles/opendxpadmin/img/filetype-not-supported.svg');
+        } catch (FilesystemException $e) {
+            Logger::error(
+                "File System error for asset thumbnail {$config['thumbnail_name']} from config {$config['type']} for file {$filename}",
+                ['exception' => $e]
+            );
+        } catch (\Throwable) {
+            Logger::error(
+                "Unable to generate asset thumbnail {$config['thumbnail_name']} from config {$config['type']} for file {$filename}"
+            );
         }
+
+        return new RedirectResponse('/bundles/opendxpadmin/img/filetype-not-supported.svg');
     }
 
     public function robotsTxtAction(Request $request): Response


### PR DESCRIPTION
<!--

Before submitting a contribution, please make sure you’re working on the correct branch:

- Bug fixes → target the latest maintenance branch (`1.0`)
- Features or improvements → target the main development branch (`1.x`)

> Note: All bug fixes merged into maintenance branches are regularly synced into the `1.x` dev branch.

## Your pull request must meet all of the following requirements:

- [x] I have read and accepted the [CLA guidelines](/CLA.md).
- [ ] Features are properly documented in the `doc/` folder.
- [x] Bug fixes include a short guide on how to reproduce the issue.
      → The target branch must be the oldest actively supported version (e.g. `1.0`; see `README.md` for details).
- [x] Code follows project standards and passes all checks (e.g. PhpStan).

**Pull requests that don't follow these rules may be closed without comment.**

-->

## Changes in this pull request  
Resolves issue where errors during thumbnail requests were never good enough to find out what or where it happened. The "see logs for details" was unhelpful and there were never anything else in the log.