### PR TITLE
fix: nack failed asset preview thumbnail generation instead of silent ack

### DIFF
--- a/lib/Exception/ThumbnailGenerationFailedException.php
+++ b/lib/Exception/ThumbnailGenerationFailedException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Exception;
+
+use RuntimeException;
+
+class ThumbnailGenerationFailedException extends RuntimeException
+{
+}

--- a/lib/Messenger/Handler/AssetPreviewImageHandler.php
+++ b/lib/Messenger/Handler/AssetPreviewImageHandler.php
@@ -54,6 +54,8 @@ class AssetPreviewImageHandler implements BatchHandlerInterface
                 } elseif ($asset instanceof Asset\Document || $asset instanceof Asset\Video) {
                     $thumbnail = $asset->getImageThumbnail(Asset\Image\Thumbnail\Config::getPreviewConfig());
                 } elseif ($asset instanceof Asset\Folder) {
+                    // no exists() verification needed here: getPreviewImage() redispatches
+                    // itself on read while tile thumbnails are still missing
                     $asset->getPreviewImage(true);
                 }
 

--- a/lib/Messenger/Handler/AssetPreviewImageHandler.php
+++ b/lib/Messenger/Handler/AssetPreviewImageHandler.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace OpenDxp\Messenger\Handler;
 
+use OpenDxp\Exception\ThumbnailGenerationFailedException;
 use OpenDxp\Messenger\AssetPreviewImageMessage;
 use OpenDxp\Model\Asset;
 use Psr\Log\LoggerInterface;
@@ -47,14 +48,26 @@ class AssetPreviewImageHandler implements BatchHandlerInterface
             try {
                 $asset = Asset::getById($message->getId());
 
+                $thumbnail = null;
                 if ($asset instanceof Asset\Image) {
-                    $asset->getThumbnail(Asset\Image\Thumbnail\Config::getPreviewConfig())->generate(false);
-                } elseif ($asset instanceof Asset\Document) {
-                    $asset->getImageThumbnail(Asset\Image\Thumbnail\Config::getPreviewConfig())->generate(false);
-                } elseif ($asset instanceof Asset\Video) {
-                    $asset->getImageThumbnail(Asset\Image\Thumbnail\Config::getPreviewConfig())->generate(false);
+                    $thumbnail = $asset->getThumbnail(Asset\Image\Thumbnail\Config::getPreviewConfig());
+                } elseif ($asset instanceof Asset\Document || $asset instanceof Asset\Video) {
+                    $thumbnail = $asset->getImageThumbnail(Asset\Image\Thumbnail\Config::getPreviewConfig());
                 } elseif ($asset instanceof Asset\Folder) {
                     $asset->getPreviewImage(true);
+                }
+
+                if ($thumbnail !== null) {
+                    $thumbnail->generate(false);
+
+                    if (!$thumbnail->exists()) {
+                        // generation errors are caught and logged inside generate(), the path reference
+                        // then points to the "filetype not supported" placeholder instead of a thumbnail
+                        throw new ThumbnailGenerationFailedException(sprintf(
+                            'Unable to generate preview image thumbnail for asset %d, see previous log entries for details',
+                            $message->getId()
+                        ));
+                    }
                 }
 
                 $ack->ack($message);

--- a/tests/Model/Messenger/AssetPreviewImageHandlerTest.php
+++ b/tests/Model/Messenger/AssetPreviewImageHandlerTest.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Tests\Model\Messenger;
+
+use OpenDxp\Exception\ThumbnailGenerationFailedException;
+use OpenDxp\Messenger\AssetPreviewImageMessage;
+use OpenDxp\Messenger\Handler\AssetPreviewImageHandler;
+use OpenDxp\Model\Asset;
+use OpenDxp\Tests\Support\Test\ModelTestCase;
+use OpenDxp\Tests\Support\Util\TestHelper;
+use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\Handler\Acknowledger;
+use Throwable;
+
+class AssetPreviewImageHandlerTest extends ModelTestCase
+{
+    public function testPreviewImageIsGeneratedForValidImage(): void
+    {
+        $asset = TestHelper::createImageAsset();
+
+        $previewConfig = Asset\Image\Thumbnail\Config::getPreviewConfig();
+        $this->assertFalse($asset->getThumbnail($previewConfig)->exists());
+
+        $error = $this->handleMessage(new AssetPreviewImageMessage($asset->getId()));
+
+        $this->assertNull($error);
+        $this->assertTrue($asset->getThumbnail($previewConfig)->exists());
+    }
+
+    public function testFailedPreviewImageGenerationIsNacked(): void
+    {
+        $asset = TestHelper::createImageAsset('', 'this-is-not-a-valid-image');
+
+        $error = $this->handleMessage(new AssetPreviewImageMessage($asset->getId()));
+
+        $this->assertInstanceOf(ThumbnailGenerationFailedException::class, $error);
+        $this->assertFalse($asset->getThumbnail(Asset\Image\Thumbnail\Config::getPreviewConfig())->exists());
+    }
+
+    private function handleMessage(AssetPreviewImageMessage $message): ?Throwable
+    {
+        $error = null;
+        $ack = new Acknowledger(
+            AssetPreviewImageHandler::class,
+            function (?Throwable $e) use (&$error): void {
+                $error = $e;
+            }
+        );
+
+        $handler = new AssetPreviewImageHandler(new NullLogger());
+        $handler($message, $ack);
+        $handler->flush(true);
+
+        return $error;
+    }
+}


### PR DESCRIPTION
fix: nack failed asset preview thumbnail generation instead of silent ack

Thumbnail::generate() catches and only logs processing errors, so the AssetPreviewImageHandler always acknowledged messages even when no thumbnail was created. Failed generations were invisible (no retry, no failure transport entry) and the admin folder preview kept showing the loading spinner forever (not fixed by https://github.com/open-dxp/admin-bundle/pull/90 ).

The handler now verifies via exists() that the preview thumbnail was actually created and throws ThumbnailGenerationFailedException otherwise, which nacks the message and makes the failure visible to the messenger retry/failure handling.

