### PR TITLE
Bugfix: Make ImageThumbnail getAsset() return type nullable

### DIFF
--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/README.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
 
+## OpenDXP 1.4.0
+- Bugfix: `ImageThumbnailInterface::getAsset()` and `ImageThumbnailTrait::getAsset()` now declare a nullable return type (`?Asset` instead of `Asset`), matching the already-nullable `$asset` property. A thumbnail built without a backing asset (e.g. from a raw path reference) previously threw a `TypeError` because `getAsset()` returned `null` while promising a non-nullable `Asset`. Note: this widens the return type of a public API method to nullable — callers must now handle a possible `null` return value [#166](https://github.com/open-dxp/opendxp/pull/166)
+
 ## OpenDXP 1.3.3
 - Chore: Fix infinite-loop typo and stale routing docblock [#156](https://github.com/open-dxp/opendxp/pull/156)
 - Chore: Refactor composite index generation, permission checks, and serialization handling [#155](https://github.com/open-dxp/opendxp/pull/155):

--- a/models/Asset/Thumbnail/ImageThumbnailInterface.php
+++ b/models/Asset/Thumbnail/ImageThumbnailInterface.php
@@ -45,7 +45,7 @@ interface ImageThumbnailInterface
 
     public function getDimensions(): array;
 
-    public function getAsset(): Asset;
+    public function getAsset(): ?Asset;
 
     public function getConfig(): ?Config;
 

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -242,7 +242,7 @@ trait ImageThumbnailTrait
         ];
     }
 
-    public function getAsset(): Asset
+    public function getAsset(): ?Asset
     {
         return $this->asset;
     }

--- a/models/Asset/Thumbnail/ImageThumbnailTrait.php
+++ b/models/Asset/Thumbnail/ImageThumbnailTrait.php
@@ -198,7 +198,7 @@ trait ImageThumbnailTrait
             $asset = $this->getAsset();
             $dimensions = [];
 
-            if ($config) {
+            if ($config && $asset !== null) {
                 $thumbnail = $asset->getDao()->getCachedThumbnail($config->getName(), $this->getFilename());
                 if (isset($thumbnail['width'], $thumbnail['height'])) {
                     $dimensions['width'] = $thumbnail['width'];
@@ -380,9 +380,13 @@ trait ImageThumbnailTrait
 
     public function getFileSize(): ?int
     {
-        $thumbnail = $this->getAsset()->getDao()->getCachedThumbnail($this->getConfig()->getName(), $this->getFilename());
-        if ($thumbnail && $thumbnail['filesize']) {
-            return $thumbnail['filesize'];
+        $asset = $this->getAsset();
+        $config = $this->getConfig();
+        if ($asset !== null && $config !== null) {
+            $thumbnail = $asset->getDao()->getCachedThumbnail($config->getName(), $this->getFilename());
+            if ($thumbnail && $thumbnail['filesize']) {
+                return $thumbnail['filesize'];
+            }
         }
 
         $pathReference = $this->getPathReference(false);

--- a/tests/Unit/Model/Asset/Thumbnail/ImageThumbnailNullAssetTest.php
+++ b/tests/Unit/Model/Asset/Thumbnail/ImageThumbnailNullAssetTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (https://pimcore.com)
+ * @copyright  Modification Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Tests\Unit\Model\Asset\Thumbnail;
+
+use OpenDxp\Model\Asset\Document\ImageThumbnail as DocumentImageThumbnail;
+use OpenDxp\Model\Asset\Video\ImageThumbnail as VideoImageThumbnail;
+use OpenDxp\Tests\Support\Test\TestCase;
+
+/**
+ * A thumbnail may be constructed without a backing asset (its `$asset` property is
+ * nullable). `getAsset()` must therefore be able to return `null` instead of violating
+ * its own return type with a `TypeError`.
+ */
+class ImageThumbnailNullAssetTest extends TestCase
+{
+    public function testVideoImageThumbnailWithoutAssetReturnsNull(): void
+    {
+        $thumbnail = new VideoImageThumbnail(null);
+
+        $this->assertNull($thumbnail->getAsset());
+    }
+
+    public function testDocumentImageThumbnailWithoutAssetReturnsNull(): void
+    {
+        $thumbnail = new DocumentImageThumbnail(null);
+
+        $this->assertNull($thumbnail->getAsset());
+    }
+}


### PR DESCRIPTION
### Changes in this pull request

`Asset\Image\Thumbnail`, `Asset\Video\ImageThumbnail` and `Asset\Document\ImageThumbnail`
all use `ImageThumbnailTrait`, whose `$asset` property is declared `?Asset` — a thumbnail
can legitimately exist without a backing asset (e.g. when built from a raw path reference).

However both `ImageThumbnailInterface::getAsset()` and `ImageThumbnailTrait::getAsset()`
declared a non-nullable `: Asset` return type. When the underlying asset is `null`, calling
`getAsset()` violates its own return type and throws a `TypeError`
("Return value must be of type Asset, null returned"). This surfaces when a thumbnail's
`__toString()` / `getPath()` is rendered for a thumbnail whose asset could not be resolved.

This PR declares the return type as `?Asset` on both the interface and the trait, so the
signature matches the already-nullable property and the actual runtime behaviour.

### Additional info

- **BC**: widens the return type of a public API method to nullable — callers must now
  handle a possible `null`. Existing implementations declaring `: Asset` stay compatible
  (covariant). Inherited from the upstream Pimcore inconsistency.
