### PR TITLE
Add indexed relation lookup as opt-in fast path, keep LIKE fallback unchanged

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Extension/RelationFilterConditionParser.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/RelationFilterConditionParser.php
@@ -63,15 +63,28 @@ trait RelationFilterConditionParser
                     $quotedId = $db->quote($id);
                     $typeCondition = $type !== null ? ' AND type = ' . $db->quote($type) : '';
 
-                    $directMatch = "SELECT src_id FROM $relationsTable WHERE ownertype = $quotedOwnerType AND fieldname = $quotedFieldName AND dest_id = $quotedId$typeCondition";
+                    $directMatch = sprintf(
+                        'SELECT src_id FROM %s WHERE ownertype = %s AND fieldname = %s AND dest_id = %s%s',
+                        $relationsTable,
+                        $quotedOwnerType,
+                        $quotedFieldName,
+                        $quotedId,
+                        $typeCondition
+                    );
 
                     // Variants inherit the relation from their parent instead of storing their own row, so match those too.
-                    $inheritedMatch = "SELECT child.id FROM objects child
-                        WHERE child.classId = $quotedClassId
-                          AND NOT EXISTS (SELECT 1 FROM $relationsTable r WHERE r.src_id = child.id AND r.fieldname = $quotedFieldName)
-                          AND child.parentId IN ($directMatch)";
+                    $inheritedMatch = sprintf(
+                        'SELECT child.id FROM objects child
+                        WHERE child.classId = %s
+                          AND NOT EXISTS (SELECT 1 FROM %s r WHERE r.src_id = child.id AND r.fieldname = %s)
+                          AND child.parentId IN (%s)',
+                        $quotedClassId,
+                        $relationsTable,
+                        $quotedFieldName,
+                        $directMatch
+                    );
 
-                    return "id IN ($directMatch UNION $inheritedMatch)";
+                    return sprintf('id IN (%s UNION %s)', $directMatch, $inheritedMatch);
                 },
                 $values,
             );

--- a/models/DataObject/ClassDefinition/Data/Extension/RelationFilterConditionParser.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/RelationFilterConditionParser.php
@@ -26,7 +26,7 @@ use OpenDxp\Db\Helper;
 trait RelationFilterConditionParser
 {
     /**
-     * Builds the filter condition for a relation field; pass $classId to use the fast indexed lookup instead of the old LIKE scan.
+     * Builds the filter condition for a relation field; pass $classId to use fast indexed lookup.
      */
     public function getRelationFilterCondition(?string $value, string $operator, string $name, string $brickPrefix = '', ?string $classId = null, ?string $destinationType = null): string
     {

--- a/models/DataObject/ClassDefinition/Data/Extension/RelationFilterConditionParser.php
+++ b/models/DataObject/ClassDefinition/Data/Extension/RelationFilterConditionParser.php
@@ -26,9 +26,9 @@ use OpenDxp\Db\Helper;
 trait RelationFilterConditionParser
 {
     /**
-     * Parses filter value of a relation field and creates the filter condition
+     * Builds the filter condition for a relation field; pass $classId to use the fast indexed lookup instead of the old LIKE scan.
      */
-    public function getRelationFilterCondition(?string $value, string $operator, string $name, string $brickPrefix = ''): string
+    public function getRelationFilterCondition(?string $value, string $operator, string $name, string $brickPrefix = '', ?string $classId = null, ?string $destinationType = null): string
     {
         $db = \OpenDxp\Db::get();
         $key = $brickPrefix . $db->quoteIdentifier($name);
@@ -36,19 +36,62 @@ trait RelationFilterConditionParser
         if ($value === null || $value === 'null') {
             return $result;
         }
-        if ($operator === '=') {
-            return $key . ' = ' . $db->quote($value);
-        }
-        $values = explode(',', $value);
-        $fieldConditions = array_map(function ($value) use ($key, $db) {
-            $quotedValue = $db->quote('%,' . Helper::escapeLike($value) . ',%');
 
-            return $key . ' LIKE ' . $quotedValue . ' ';
-        }, array_filter($values));
-        if ($fieldConditions !== []) {
+        $values = array_filter(explode(',', $value));
+
+        if ($values === []) {
+            return $result;
+        }
+
+        if ($classId !== null) {
+            // Look up the relation table directly instead of scanning the text column with LIKE.
+            $relationsTable = $db->quoteIdentifier('object_relations_' . $classId);
+            $quotedClassId = $db->quote($classId);
+            $quotedFieldName = $db->quote($name);
+            $quotedOwnerType = $db->quote('object');
+
+            $fieldConditions = array_map(
+                static function (string $value) use ($relationsTable, $quotedClassId, $quotedFieldName, $quotedOwnerType, $destinationType, $db): string {
+                    // A value can be a plain id ("60") or "type|id" ("object|60"); the embedded type wins if present.
+                    $id = $value;
+                    $type = $destinationType;
+
+                    if (str_contains($value, '|')) {
+                        [$type, $id] = explode('|', $value, 2);
+                    }
+
+                    $quotedId = $db->quote($id);
+                    $typeCondition = $type !== null ? ' AND type = ' . $db->quote($type) : '';
+
+                    $directMatch = "SELECT src_id FROM $relationsTable WHERE ownertype = $quotedOwnerType AND fieldname = $quotedFieldName AND dest_id = $quotedId$typeCondition";
+
+                    // Variants inherit the relation from their parent instead of storing their own row, so match those too.
+                    $inheritedMatch = "SELECT child.id FROM objects child
+                        WHERE child.classId = $quotedClassId
+                          AND NOT EXISTS (SELECT 1 FROM $relationsTable r WHERE r.src_id = child.id AND r.fieldname = $quotedFieldName)
+                          AND child.parentId IN ($directMatch)";
+
+                    return "id IN ($directMatch UNION $inheritedMatch)";
+                },
+                $values,
+            );
+
             return '(' . implode(' AND ', $fieldConditions) . ')';
         }
 
-        return $result;
+        if ($operator === '=') {
+            return $key . ' = ' . $db->quote($value);
+        }
+
+        $fieldConditions = array_map(static function ($value) use ($key, $db) {
+            $escaped = Helper::escapeLike($value);
+            // Match either a plain id or a "type|id" entry, since relations store either format.
+            $quotedBare = $db->quote('%,' . $escaped . ',%');
+            $quotedPrefixed = $db->quote('%|' . $escaped . ',%');
+
+            return sprintf('(%1$s LIKE %2$s OR %1$s LIKE %3$s)', $key, $quotedBare, $quotedPrefixed);
+        }, $values);
+
+        return '(' . implode(' AND ', $fieldConditions) . ')';
     }
 }

--- a/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyObjectRelation.php
@@ -691,7 +691,10 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
         }
 
         if ($operator === '=') {
-            $listing->addConditionParam('`'.$this->getName().'` LIKE ?', '%,'.$data.',%');
+            $classId = $listing instanceof DataObject\Listing\Concrete ? $listing->getClassId() : null;
+            $listing->addConditionParam(
+                $this->getRelationFilterCondition((string) $data, $operator, $this->getName(), '', $classId)
+            );
 
             return $listing;
         }
@@ -707,8 +710,9 @@ class ManyToManyObjectRelation extends AbstractRelations implements QueryResourc
     {
         $name = $params['name'] ?: $this->name;
         $brickPrefix = !empty($params['brickPrefix']) ? $params['brickPrefix'] : '';
+        $classId = isset($params['classId']) ? (string) $params['classId'] : null;
 
-        return $this->getRelationFilterCondition($value, $operator, $name, $brickPrefix);
+        return $this->getRelationFilterCondition($value, $operator, $name, $brickPrefix, $classId);
     }
 
     public function getQueryColumnType(): string

--- a/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ManyToManyRelation.php
@@ -750,7 +750,10 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
         }
 
         if ($operator === '=') {
-            $listing->addConditionParam('`'.$this->getName().'` LIKE ?', '%,'.$data['type'].'|'.$data['id'].',%');
+            $classId = $listing instanceof DataObject\Listing\Concrete ? $listing->getClassId() : null;
+            $listing->addConditionParam(
+                $this->getRelationFilterCondition((string) $data['id'], $operator, $this->getName(), '', $classId, (string) $data['type'])
+            );
 
             return $listing;
         }
@@ -766,8 +769,9 @@ class ManyToManyRelation extends AbstractRelations implements QueryResourcePersi
     {
         $name = $params['name'] ?: $this->name;
         $brickPrefix = !empty($params['brickPrefix']) ? $params['brickPrefix'] : '';
+        $classId = isset($params['classId']) ? (string) $params['classId'] : null;
 
-        return $this->getRelationFilterCondition($value, $operator, $name, $brickPrefix);
+        return $this->getRelationFilterCondition($value, $operator, $name, $brickPrefix, $classId);
     }
 
     public function getQueryColumnType(): string


### PR DESCRIPTION
This significantly improves performance when filtering a large set of objects with enabled `manyToMany|maynToManyObject` relations.