### PR TITLE
Join localized fieldcollection fields in object listings

### DIFF
--- a/doc/05_Objects/03_Working_with_PHP_API.md
+++ b/doc/05_Objects/03_Working_with_PHP_API.md
@@ -363,6 +363,21 @@ The object listing of this example only delivers objects of the type Collectiont
 * a Fieldcollection of the type `MyCollection` and the value `testinput` in the attribute `myinput` and
 * a Fieldcollection in the field `collection` of the type `MyCollection` and the value `hugo` in the attribute `myinput`.
 
+### Filter Objects by localized attributes from Field Collections
+If a field collection has a `localizedfields` block, its localized attributes are joined under a separate alias
+with the suffix `_localized`: `FIELDCOLLECTIONTYPE_localized` or, with a fieldname, `FIELDCOLLECTIONTYPE~FIELDNAME_localized`.
+This alias is joined to the exact same field collection item (matched by `index` and `fieldname`, not just the
+object id), so it always lines up with the plain attributes of that item.
+
+```php
+$list = new DataObject\Collectiontest\Listing();
+$list->addFieldCollection("MyCollection", "collection");
+$list->setLocale("en");
+$list->setCondition("`MyCollection~collection_localized`.mylocalizedinput = 'hugo'");
+```
+
+The language used for the join is resolved the same way as for localized fields on the object itself: the
+listing's `setLocale()`, then the current request locale, then the system default language.
 
 <a name="zendPaginatorListing">&nbsp;</a>
 

--- a/models/DataObject/Listing/Concrete/Dao.php
+++ b/models/DataObject/Listing/Concrete/Dao.php
@@ -182,6 +182,28 @@ CONDITION;
 
                 // add join
                 $queryBuilder->leftJoin($this->getTableName(), $table, $this->db->quoteIdentifier($name), $condition);
+
+                // add localizedfields block, if the fieldcollection contains localized fields
+                // same as in bricks below (line 235)
+                $fieldCollectionDefinition = DataObject\Fieldcollection\Definition::getByKey($fc['type']);
+
+                if ($fieldCollectionDefinition instanceof DataObject\Fieldcollection\Definition
+                    && $fieldCollectionDefinition->getFieldDefinition('localizedfields')
+                ) {
+                    $language = $this->db->quote($this->getLocalizedBrickLanguage());
+                    $localizedTable = 'object_collection_' . $fc['type'] . '_localized_' . $this->model->getClassId();
+                    $localizedName = $name . '_localized';
+
+                    $queryBuilder->leftJoin($this->getTableName(), $localizedTable, $this->db->quoteIdentifier($localizedName),
+                        <<<CONDITION
+1
+ AND {$this->db->quoteIdentifier($localizedName)}.ooo_id = {$this->db->quoteIdentifier($name)}.id
+ AND {$this->db->quoteIdentifier($localizedName)}.index = {$this->db->quoteIdentifier($name)}.index
+ AND {$this->db->quoteIdentifier($localizedName)}.fieldname = {$this->db->quoteIdentifier($name)}.fieldname
+ AND {$this->db->quoteIdentifier($localizedName)}.language = {$language}
+CONDITION
+                    );
+                }
             }
         }
 

--- a/tests/Model/Relations/FieldcollectionTest.php
+++ b/tests/Model/Relations/FieldcollectionTest.php
@@ -23,6 +23,7 @@ use OpenDxp\Model\DataObject\Fieldcollection;
 use OpenDxp\Model\DataObject\Fieldcollection\Definition;
 use OpenDxp\Model\DataObject\RelationTest;
 use OpenDxp\Model\DataObject\Service;
+use OpenDxp\Model\DataObject\Unittest;
 use OpenDxp\Tests\Support\Test\ModelTestCase;
 use OpenDxp\Tests\Support\Util\TestHelper;
 
@@ -241,6 +242,44 @@ class FieldcollectionTest extends ModelTestCase
         $loadedFieldcollectionItem = $object->getFieldcollection()->get(1);
         $lrel = $loadedFieldcollectionItem->getLRelation('en');
         $this->assertEquals(null, $lrel);
+    }
+
+    public function testLocalizedFieldInsideFieldCollectionListing(): void
+    {
+        $object = TestHelper::createEmptyObject();
+
+        $items = new Fieldcollection();
+
+        $item1 = new FieldCollection\Data\Unittestfieldcollection();
+        $item1->setFieldinput1('one');
+        $item1->setLinput('hugo', 'en');
+
+        $item2 = new FieldCollection\Data\Unittestfieldcollection();
+        $item2->setFieldinput1('two');
+        $item2->setLinput('franz', 'en');
+
+        $items->add($item1);
+        $items->add($item2);
+
+        $object->setFieldcollection($items);
+        $object->save();
+
+        // item1's plain attribute together with item1's own localized attribute must match
+        $list = new Unittest\Listing();
+        $list->setLocale('en');
+        $list->addFieldCollection('unittestfieldcollection', 'fieldcollection');
+        $list->setCondition("`unittestfieldcollection~fieldcollection`.fieldinput1 = 'one' AND `unittestfieldcollection~fieldcollection_localized`.linput = 'hugo'");
+        $list->load();
+        $this->assertCount(1, $list->getObjects());
+        $this->assertEquals($object->getId(), $list->getObjects()[0]->getId());
+
+        // item1's plain attribute must never be paired with item2's localized attribute
+        $list = new Unittest\Listing();
+        $list->setLocale('en');
+        $list->addFieldCollection('unittestfieldcollection', 'fieldcollection');
+        $list->setCondition("`unittestfieldcollection~fieldcollection`.fieldinput1 = 'one' AND `unittestfieldcollection~fieldcollection_localized`.linput = 'franz'");
+        $list->load();
+        $this->assertCount(0, $list->getObjects());
     }
 
     public function testInputFieldWithNullAndThenDefaultValue(): void


### PR DESCRIPTION
Same as in object brick joins, we want to access the localized fields within fieldcollections:

https://github.com/open-dxp/opendxp/blob/ef289901017b34b8a5c679113a75ddb32573020f/models/DataObject/Listing/Concrete/Dao.php#L209-L222