### PR TITLE
Introduce Permission Voters (User / Element)

### DIFF
--- a/bundles/ApplicationLoggerBundle/src/Installer.php
+++ b/bundles/ApplicationLoggerBundle/src/Installer.php
@@ -16,16 +16,14 @@ declare(strict_types=1);
 
 namespace OpenDxp\Bundle\ApplicationLoggerBundle;
 
+use OpenDxp\Bundle\ApplicationLoggerBundle\Security\ApplicationLoggerPermission;
 use OpenDxp\Extension\Bundle\Installer\SettingsStoreAwareInstaller;
+use OpenDxp\Security\PermissionAttribute;
 use Override;
 
 class Installer extends SettingsStoreAwareInstaller
 {
     protected const string USER_PERMISSIONS_CATEGORY = 'OpenDxp Application Logger Bundle';
-
-    protected const array USER_PERMISSIONS = [
-        'application_logging',
-    ];
 
     #[Override]
     public function install(): void
@@ -82,9 +80,9 @@ class Installer extends SettingsStoreAwareInstaller
     {
         $db = \OpenDxp\Db::get();
 
-        foreach (self::USER_PERMISSIONS as $permission) {
+        foreach (ApplicationLoggerPermission::cases() as $permission) {
             $db->insert('users_permission_definitions', [
-                $db->quoteIdentifier('key') => $permission,
+                $db->quoteIdentifier('key') => PermissionAttribute::for($permission->value),
                 $db->quoteIdentifier('category') => self::USER_PERMISSIONS_CATEGORY,
             ]);
         }
@@ -94,9 +92,9 @@ class Installer extends SettingsStoreAwareInstaller
     {
         $db = \OpenDxp\Db::get();
 
-        foreach (self::USER_PERMISSIONS as $permission) {
+        foreach (ApplicationLoggerPermission::cases() as $permission) {
             $db->delete('users_permission_definitions', [
-                $db->quoteIdentifier('key') => $permission,
+                $db->quoteIdentifier('key') => PermissionAttribute::for($permission->value),
             ]);
         }
     }

--- a/bundles/ApplicationLoggerBundle/src/Security/ApplicationLoggerPermission.php
+++ b/bundles/ApplicationLoggerBundle/src/Security/ApplicationLoggerPermission.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (https://pimcore.com)
+ * @copyright  Modification Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Bundle\ApplicationLoggerBundle\Security;
+
+enum ApplicationLoggerPermission: string
+{
+    case ApplicationLogging = 'opendxp:security:permission:application_logging';
+}

--- a/bundles/CoreBundle/config/services.yaml
+++ b/bundles/CoreBundle/config/services.yaml
@@ -166,6 +166,9 @@ services:
     # user-checker checking opendxp users for validity
     OpenDxp\Security\User\UserChecker: ~
 
+    OpenDxp\Security\Voter\UserPermissionVoter: ~
+    OpenDxp\Security\Voter\ElementPermissionVoter: ~
+
     #
     # System Settings Services
 

--- a/bundles/CustomReportsBundle/src/Installer.php
+++ b/bundles/CustomReportsBundle/src/Installer.php
@@ -16,17 +16,14 @@ declare(strict_types=1);
 
 namespace OpenDxp\Bundle\CustomReportsBundle;
 
+use OpenDxp\Bundle\CustomReportsBundle\Security\CustomReportsPermission;
 use OpenDxp\Extension\Bundle\Installer\SettingsStoreAwareInstaller;
+use OpenDxp\Security\PermissionAttribute;
 use Override;
 
 class Installer extends SettingsStoreAwareInstaller
 {
     protected const string USER_PERMISSIONS_CATEGORY = 'OpenDxp Custom Reports Bundle';
-
-    protected const array USER_PERMISSIONS = [
-        'reports',
-        'reports_config',
-    ];
 
     #[Override]
     public function install(): void
@@ -46,9 +43,9 @@ class Installer extends SettingsStoreAwareInstaller
     {
         $db = \OpenDxp\Db::get();
 
-        foreach (self::USER_PERMISSIONS as $permission) {
+        foreach (CustomReportsPermission::cases() as $permission) {
             $db->insert('users_permission_definitions', [
-                $db->quoteIdentifier('key') => $permission,
+                $db->quoteIdentifier('key') => PermissionAttribute::for($permission->value),
                 $db->quoteIdentifier('category') => self::USER_PERMISSIONS_CATEGORY,
             ]);
         }
@@ -58,9 +55,9 @@ class Installer extends SettingsStoreAwareInstaller
     {
         $db = \OpenDxp\Db::get();
 
-        foreach (self::USER_PERMISSIONS as $permission) {
+        foreach (CustomReportsPermission::cases() as $permission) {
             $db->delete('users_permission_definitions', [
-                $db->quoteIdentifier('key') => $permission,
+                $db->quoteIdentifier('key') => PermissionAttribute::for($permission->value),
             ]);
         }
     }

--- a/bundles/CustomReportsBundle/src/Security/CustomReportsPermission.php
+++ b/bundles/CustomReportsBundle/src/Security/CustomReportsPermission.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (https://pimcore.com)
+ * @copyright  Modification Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Bundle\CustomReportsBundle\Security;
+
+enum CustomReportsPermission: string
+{
+    case Reports        = 'opendxp:security:permission:reports';
+    case ReportsConfig  = 'opendxp:security:permission:reports_config';
+}

--- a/bundles/GenericExecutionEngineBundle/src/Installer.php
+++ b/bundles/GenericExecutionEngineBundle/src/Installer.php
@@ -22,9 +22,10 @@ use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaException;
 use OpenDxp\Bundle\GenericExecutionEngineBundle\Entity\JobRun;
-use OpenDxp\Bundle\GenericExecutionEngineBundle\Utils\Constants\PermissionConstants;
+use OpenDxp\Bundle\GenericExecutionEngineBundle\Security\GenericExecutionEnginePermission;
 use OpenDxp\Bundle\GenericExecutionEngineBundle\Utils\Constants\TableConstants;
 use OpenDxp\Extension\Bundle\Installer\SettingsStoreAwareInstaller;
+use OpenDxp\Security\PermissionAttribute;
 use Override;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
@@ -34,11 +35,6 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 final class Installer extends SettingsStoreAwareInstaller
 {
     public const string USER_PERMISSIONS_CATEGORY = 'OpenDxp Generic Execution Engine';
-
-    protected const array USER_PERMISSIONS = [
-        PermissionConstants::GEE_JOB_RUN,
-        PermissionConstants::GEE_SEE_ALL_JOB_RUNS,
-    ];
 
     public function __construct(
         private readonly Connection $db,
@@ -211,7 +207,7 @@ final class Installer extends SettingsStoreAwareInstaller
     private function addUserPermission(Schema $schema): void
     {
         if ($schema->hasTable(TableConstants::USER_PERMISSION_DEF_TABLE)) {
-            foreach (self::USER_PERMISSIONS as $permission) {
+            foreach (GenericExecutionEnginePermission::cases() as $permission) {
                 $queryBuilder = $this->db->createQueryBuilder();
                 $queryBuilder
                     ->insert(TableConstants::USER_PERMISSION_DEF_TABLE)
@@ -220,7 +216,7 @@ final class Installer extends SettingsStoreAwareInstaller
                         $this->db->quoteIdentifier('category') => ':category',
                     ])
                     ->setParameters([
-                        'key' => $permission,
+                        'key' => PermissionAttribute::for($permission->value),
                         'category' => self::USER_PERMISSIONS_CATEGORY,
                     ]);
 
@@ -235,12 +231,12 @@ final class Installer extends SettingsStoreAwareInstaller
     private function removeUserPermission(Schema $schema): void
     {
         if ($schema->hasTable(TableConstants::USER_PERMISSION_DEF_TABLE)) {
-            foreach (self::USER_PERMISSIONS as $permission) {
+            foreach (GenericExecutionEnginePermission::cases() as $permission) {
                 $queryBuilder = $this->db->createQueryBuilder();
                 $queryBuilder
                     ->delete(TableConstants::USER_PERMISSION_DEF_TABLE)
                     ->where($this->db->quoteIdentifier('key') . ' = :key')
-                    ->setParameter('key', $permission);
+                    ->setParameter('key', PermissionAttribute::for($permission->value));
 
                 $queryBuilder->executeStatement();
             }

--- a/bundles/GenericExecutionEngineBundle/src/Security/GenericExecutionEnginePermission.php
+++ b/bundles/GenericExecutionEngineBundle/src/Security/GenericExecutionEnginePermission.php
@@ -14,17 +14,10 @@ declare(strict_types=1);
  * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
  */
 
-namespace OpenDxp\Bundle\GenericExecutionEngineBundle\Utils\Constants;
+namespace OpenDxp\Bundle\GenericExecutionEngineBundle\Security;
 
-/**
- * @internal
- */
-class PermissionConstants
+enum GenericExecutionEnginePermission: string
 {
-    /**
-     * Permission have a max length of 50 chars!
-     */
-    public const string GEE_JOB_RUN = 'gee_job_run_permission';
-
-    public const string GEE_SEE_ALL_JOB_RUNS = 'gee_see_all_job_runs_permission';
+    case JobRun         = 'opendxp:security:permission:gee_job_run_permission';
+    case SeeAllJobRuns  = 'opendxp:security:permission:gee_see_all_job_runs_permission';
 }

--- a/bundles/GenericExecutionEngineBundle/src/Security/PermissionService.php
+++ b/bundles/GenericExecutionEngineBundle/src/Security/PermissionService.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 namespace OpenDxp\Bundle\GenericExecutionEngineBundle\Security;
 
 use OpenDxp\Bundle\GenericExecutionEngineBundle\Exception\PermissionException;
-use OpenDxp\Bundle\GenericExecutionEngineBundle\Utils\Constants\PermissionConstants;
 use OpenDxp\Model\UserInterface;
+use OpenDxp\Security\PermissionAttribute;
 use OpenDxp\Tool\Authentication;
 
 /**
@@ -55,7 +55,7 @@ final readonly class PermissionService implements PermissionServiceInterface
             return false;
         }
 
-        return $this->user->isAllowed(PermissionConstants::GEE_JOB_RUN);
+        return $this->user->isAllowed(PermissionAttribute::for(GenericExecutionEnginePermission::JobRun->value));
     }
 
     public function isAllowedToSeeAllJobRuns(): bool
@@ -64,6 +64,6 @@ final readonly class PermissionService implements PermissionServiceInterface
             return false;
         }
 
-        return $this->user->isAllowed(PermissionConstants::GEE_SEE_ALL_JOB_RUNS);
+        return $this->user->isAllowed(PermissionAttribute::for(GenericExecutionEnginePermission::SeeAllJobRuns->value));
     }
 }

--- a/bundles/GlossaryBundle/src/Installer.php
+++ b/bundles/GlossaryBundle/src/Installer.php
@@ -16,7 +16,9 @@ declare(strict_types=1);
 
 namespace OpenDxp\Bundle\GlossaryBundle;
 
+use OpenDxp\Bundle\GlossaryBundle\Security\GlossaryPermission;
 use OpenDxp\Extension\Bundle\Installer\SettingsStoreAwareInstaller;
+use OpenDxp\Security\PermissionAttribute;
 use Override;
 
 /**
@@ -25,10 +27,6 @@ use Override;
 class Installer extends SettingsStoreAwareInstaller
 {
     protected const string USER_PERMISSIONS_CATEGORY = 'OpenDxp Glossary Bundle';
-
-    protected const array USER_PERMISSIONS = [
-        'glossary',
-    ];
 
     #[Override]
     public function install(): void
@@ -50,9 +48,9 @@ class Installer extends SettingsStoreAwareInstaller
     {
         $db = \OpenDxp\Db::get();
 
-        foreach (self::USER_PERMISSIONS as $permission) {
+        foreach (GlossaryPermission::cases() as $permission) {
             $db->insert('users_permission_definitions', [
-                $db->quoteIdentifier('key') => $permission,
+                $db->quoteIdentifier('key') => PermissionAttribute::for($permission->value),
                 $db->quoteIdentifier('category') => self::USER_PERMISSIONS_CATEGORY,
             ]);
         }
@@ -62,9 +60,9 @@ class Installer extends SettingsStoreAwareInstaller
     {
         $db = \OpenDxp\Db::get();
 
-        foreach (self::USER_PERMISSIONS as $permission) {
+        foreach (GlossaryPermission::cases() as $permission) {
             $db->delete('users_permission_definitions', [
-                $db->quoteIdentifier('key') => $permission,
+                $db->quoteIdentifier('key') => PermissionAttribute::for($permission->value),
             ]);
         }
     }

--- a/bundles/GlossaryBundle/src/Security/GlossaryPermission.php
+++ b/bundles/GlossaryBundle/src/Security/GlossaryPermission.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (https://pimcore.com)
+ * @copyright  Modification Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Bundle\GlossaryBundle\Security;
+
+enum GlossaryPermission: string
+{
+    case Glossary = 'opendxp:security:permission:glossary';
+}

--- a/bundles/InstallBundle/src/Installer.php
+++ b/bundles/InstallBundle/src/Installer.php
@@ -45,7 +45,8 @@ use OpenDxp\Config;
 use OpenDxp\Console\Style\OpenDxpStyle;
 use OpenDxp\Db\Helper;
 use OpenDxp\Model\Tool\SettingsStore;
-use OpenDxp\Model\User;
+use OpenDxp\Security\CorePermission;
+use OpenDxp\Security\PermissionAttribute;
 use OpenDxp\Tool\AssetsInstaller;
 use OpenDxp\Tool\Console;
 use OpenDxp\Tool\Requirements;
@@ -814,47 +815,9 @@ class Installer
             'userOwner' => 1,
             'userModification' => 1,
         ]));
-        $userPermissions = [
-            'assets',
-            'classes',
-            'selectoptions',
-            'clear_cache',
-            'clear_fullpage_cache',
-            'clear_temp_files',
-            'dashboards',
-            'document_types',
-            'documents',
-            'emails',
-            'notes_events',
-            'objects',
-            'predefined_properties',
-            'asset_metadata',
-            'recyclebin',
-            'redirects',
-            'seemode',
-            'share_configurations',
-            'system_settings',
-            'tags_configuration',
-            'tags_assignment',
-            'tags_search',
-            'thumbnails',
-            'translations',
-            'users',
-            'website_settings',
-            'workflow_details',
-            'notifications',
-            'notifications_send',
-            'sites',
-            'objects_sort_method',
-            'objectbricks',
-            'fieldcollections',
-            'quantityValueUnits',
-            'classificationstore',
-        ];
-
-        foreach ($userPermissions as $permission) {
+        foreach (CorePermission::cases() as $permission) {
             $db->insert('users_permission_definitions', [
-                $db->quoteIdentifier('key') => $permission,
+                $db->quoteIdentifier('key') => PermissionAttribute::for($permission->value),
             ]);
         }
     }

--- a/bundles/SeoBundle/src/Installer.php
+++ b/bundles/SeoBundle/src/Installer.php
@@ -16,18 +16,14 @@ declare(strict_types=1);
 
 namespace OpenDxp\Bundle\SeoBundle;
 
+use OpenDxp\Bundle\SeoBundle\Security\SeoPermission;
 use OpenDxp\Extension\Bundle\Installer\SettingsStoreAwareInstaller;
+use OpenDxp\Security\PermissionAttribute;
 use Override;
 
 class Installer extends SettingsStoreAwareInstaller
 {
     protected const string USER_PERMISSIONS_CATEGORY = 'OpenDxp Seo Bundle';
-
-    protected const array USER_PERMISSIONS = [
-        'robots.txt',
-        'seo_document_editor',
-        'http_errors',
-    ];
 
     #[Override]
     public function install(): void
@@ -49,9 +45,9 @@ class Installer extends SettingsStoreAwareInstaller
     {
         $db = \OpenDxp\Db::get();
 
-        foreach (self::USER_PERMISSIONS as $permission) {
+        foreach (SeoPermission::cases() as $permission) {
             $db->insert('users_permission_definitions', [
-                $db->quoteIdentifier('key') => $permission,
+                $db->quoteIdentifier('key') => PermissionAttribute::for($permission->value),
                 $db->quoteIdentifier('category') => self::USER_PERMISSIONS_CATEGORY,
             ]);
         }
@@ -61,9 +57,9 @@ class Installer extends SettingsStoreAwareInstaller
     {
         $db = \OpenDxp\Db::get();
 
-        foreach (self::USER_PERMISSIONS as $permission) {
+        foreach (SeoPermission::cases() as $permission) {
             $db->delete('users_permission_definitions', [
-                $db->quoteIdentifier('key') => $permission,
+                $db->quoteIdentifier('key') => PermissionAttribute::for($permission->value),
             ]);
         }
     }

--- a/bundles/SeoBundle/src/Security/SeoPermission.php
+++ b/bundles/SeoBundle/src/Security/SeoPermission.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (https://pimcore.com)
+ * @copyright  Modification Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Bundle\SeoBundle\Security;
+
+enum SeoPermission: string
+{
+    case RobotsTxt          = 'opendxp:security:permission:robots.txt';
+    case SeoDocumentEditor  = 'opendxp:security:permission:seo_document_editor';
+    case HttpErrors         = 'opendxp:security:permission:http_errors';
+}

--- a/bundles/StaticRoutesBundle/src/Installer.php
+++ b/bundles/StaticRoutesBundle/src/Installer.php
@@ -16,8 +16,10 @@ declare(strict_types=1);
 
 namespace OpenDxp\Bundle\StaticRoutesBundle;
 
+use OpenDxp\Bundle\StaticRoutesBundle\Security\StaticRoutesPermission;
 use OpenDxp\Extension\Bundle\Installer\SettingsStoreAwareInstaller;
 use OpenDxp\Model\Tool\SettingsStore;
+use OpenDxp\Security\PermissionAttribute;
 use Override;
 
 /**
@@ -28,10 +30,6 @@ class Installer extends SettingsStoreAwareInstaller
     protected const string SETTINGS_STORE_SCOPE = 'opendxp_staticroutes';
 
     protected const string USER_PERMISSION_CATEGORY = 'OpenDxp Static Routes Bundle';
-
-    protected const array USER_PERMISSIONS = [
-        'routes',
-    ];
 
     #[Override]
     public function install(): void
@@ -52,9 +50,9 @@ class Installer extends SettingsStoreAwareInstaller
     {
         $db = \OpenDxp\Db::get();
 
-        foreach (self::USER_PERMISSIONS as $permission) {
+        foreach (StaticRoutesPermission::cases() as $permission) {
             $db->insert('users_permission_definitions', [
-                $db->quoteIdentifier('key') => $permission,
+                $db->quoteIdentifier('key') => PermissionAttribute::for($permission->value),
                 $db->quoteIdentifier('category') => self::USER_PERMISSION_CATEGORY,
             ]);
         }
@@ -64,9 +62,9 @@ class Installer extends SettingsStoreAwareInstaller
     {
         $db = \OpenDxp\Db::get();
 
-        foreach (self::USER_PERMISSIONS as $permission) {
+        foreach (StaticRoutesPermission::cases() as $permission) {
             $db->delete('users_permission_definitions', [
-                $db->quoteIdentifier('key') => $permission,
+                $db->quoteIdentifier('key') => PermissionAttribute::for($permission->value),
             ]);
         }
     }

--- a/bundles/StaticRoutesBundle/src/Security/StaticRoutesPermission.php
+++ b/bundles/StaticRoutesBundle/src/Security/StaticRoutesPermission.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (https://pimcore.com)
+ * @copyright  Modification Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Bundle\StaticRoutesBundle\Security;
+
+enum StaticRoutesPermission: string
+{
+    case Routes = 'opendxp:security:permission:routes';
+}

--- a/bundles/WordExportBundle/src/Installer.php
+++ b/bundles/WordExportBundle/src/Installer.php
@@ -16,16 +16,14 @@ declare(strict_types=1);
 
 namespace OpenDxp\Bundle\WordExportBundle;
 
+use OpenDxp\Bundle\WordExportBundle\Security\WordExportPermission;
 use OpenDxp\Extension\Bundle\Installer\SettingsStoreAwareInstaller;
+use OpenDxp\Security\PermissionAttribute;
 use Override;
 
 class Installer extends SettingsStoreAwareInstaller
 {
     protected const USER_PERMISSION_CATEGORY = 'OpenDxp Word Export Bundle';
-
-    protected const USER_PERMISSIONS = [
-        'word_export',
-    ];
 
     #[Override]
     public function install(): void
@@ -45,9 +43,9 @@ class Installer extends SettingsStoreAwareInstaller
     {
         $db = \OpenDxp\Db::get();
 
-        foreach (self::USER_PERMISSIONS as $permission) {
+        foreach (WordExportPermission::cases() as $permission) {
             $db->insert('users_permission_definitions', [
-                $db->quoteIdentifier('key') => $permission,
+                $db->quoteIdentifier('key') => PermissionAttribute::for($permission->value),
                 $db->quoteIdentifier('category') => self::USER_PERMISSION_CATEGORY,
             ]);
         }
@@ -57,9 +55,9 @@ class Installer extends SettingsStoreAwareInstaller
     {
         $db = \OpenDxp\Db::get();
 
-        foreach (self::USER_PERMISSIONS as $permission) {
+        foreach (WordExportPermission::cases() as $permission) {
             $db->delete('users_permission_definitions', [
-                $db->quoteIdentifier('key') => $permission,
+                $db->quoteIdentifier('key') => PermissionAttribute::for($permission->value),
             ]);
         }
     }

--- a/bundles/WordExportBundle/src/Security/WordExportPermission.php
+++ b/bundles/WordExportBundle/src/Security/WordExportPermission.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (https://pimcore.com)
+ * @copyright  Modification Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Bundle\WordExportBundle\Security;
+
+enum WordExportPermission: string
+{
+    case WordExport = 'opendxp:security:permission:word_export';
+}

--- a/bundles/XliffBundle/src/Installer.php
+++ b/bundles/XliffBundle/src/Installer.php
@@ -16,7 +16,9 @@ declare(strict_types=1);
 
 namespace OpenDxp\Bundle\XliffBundle;
 
+use OpenDxp\Bundle\XliffBundle\Security\XliffPermission;
 use OpenDxp\Extension\Bundle\Installer\SettingsStoreAwareInstaller;
+use OpenDxp\Security\PermissionAttribute;
 use Override;
 
 /**
@@ -25,10 +27,6 @@ use Override;
 class Installer extends SettingsStoreAwareInstaller
 {
     protected const USER_PERMISSION_CATEGORY = 'OpenDxp Xliff Bundle';
-
-    protected const USER_PERMISSIONS = [
-        'xliff_import_export',
-    ];
 
     #[Override]
     public function install(): void
@@ -48,9 +46,9 @@ class Installer extends SettingsStoreAwareInstaller
     {
         $db = \OpenDxp\Db::get();
 
-        foreach (self::USER_PERMISSIONS as $permission) {
+        foreach (XliffPermission::cases() as $permission) {
             $db->insert('users_permission_definitions', [
-                $db->quoteIdentifier('key') => $permission,
+                $db->quoteIdentifier('key') => PermissionAttribute::for($permission->value),
                 $db->quoteIdentifier('category') => self::USER_PERMISSION_CATEGORY,
             ]);
         }
@@ -60,9 +58,9 @@ class Installer extends SettingsStoreAwareInstaller
     {
         $db = \OpenDxp\Db::get();
 
-        foreach (self::USER_PERMISSIONS as $permission) {
+        foreach (XliffPermission::cases() as $permission) {
             $db->delete('users_permission_definitions', [
-                $db->quoteIdentifier('key') => $permission,
+                $db->quoteIdentifier('key') => PermissionAttribute::for($permission->value),
             ]);
         }
     }

--- a/bundles/XliffBundle/src/Security/XliffPermission.php
+++ b/bundles/XliffBundle/src/Security/XliffPermission.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (https://pimcore.com)
+ * @copyright  Modification Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Bundle\XliffBundle\Security;
+
+enum XliffPermission: string
+{
+    case XliffImportExport = 'opendxp:security:permission:xliff_import_export';
+}

--- a/doc/19_Development_Tools_and_Details/10_Security_Authentication/10_Permission_Voters.md
+++ b/doc/19_Development_Tools_and_Details/10_Security_Authentication/10_Permission_Voters.md
@@ -1,0 +1,48 @@
+# Permission Voters
+
+OpenDXP bridges its own permission checks (`User::isAllowed()` and `ElementInterface::isAllowed()`) into Symfony's authorization layer,
+so you can use `#[IsGranted]` and `Security::isGranted()`.
+
+## Two voters to rule them all
+
+### UserPermissionVoter
+Flat/global permission check, same as `$user->isAllowed($key)`. 
+Keys come from `OpenDxp\Security\CorePermission` or any bundle's own permission enum (see below).
+
+### ElementPermissionVoter
+Element ACL check, same as `$element->isAllowed($type, $user)`. 
+Keys come from `OpenDxp\Security\ElementPermission` (`View`, `Publish`, `Delete`, `Rename`, `Create`, `Settings`, `Versions`, `Properties`, `List`). 
+
+Per-language edit/view permissions and layout restrictions are a separate, non-boolean mechanism and not part of this enum.
+
+***
+
+## Flat permission check
+
+```php
+#[IsGranted(CorePermission::Assets->value)]
+class MyController extends AdminAbstractController
+{
+}
+```
+
+## Element ACL check
+
+Declarative, with the element resolved from a controller argument:
+
+```php
+#[IsGranted(ElementPermission::View->value, subject: 'asset')]
+public function myAction(Asset $asset): Response
+{
+}
+```
+
+Imperative:
+
+```php
+if ($security->isGranted(ElementPermission::View->value, $element)) {
+    // ...
+}
+
+$security->denyAccessUnlessGranted(ElementPermission::Publish->value, $element);
+```

--- a/doc/19_Development_Tools_and_Details/10_Security_Authentication/README.md
+++ b/doc/19_Development_Tools_and_Details/10_Security_Authentication/README.md
@@ -11,3 +11,5 @@ A simplified guide to this setup is illustrated in [Authenticate against OpenDXP
 
 For more complex examples, custom user providers and a full configuration reference please read the
 [Symfony Security Component documentation](https://symfony.com/doc/current/security.html).
+
+To use `#[IsGranted]`/`Security::isGranted()` against OpenDXP's own permission checks, see [Permission Voters](./10_Permission_Voters.md).

--- a/lib/Security/CorePermission.php
+++ b/lib/Security/CorePermission.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Security;
+
+enum CorePermission: string
+{
+    case Assets                = 'opendxp:security:permission:assets';
+    case Classes               = 'opendxp:security:permission:classes';
+    case Selectoptions         = 'opendxp:security:permission:selectoptions';
+    case ClearCache            = 'opendxp:security:permission:clear_cache';
+    case ClearFullpageCache    = 'opendxp:security:permission:clear_fullpage_cache';
+    case ClearTempFiles        = 'opendxp:security:permission:clear_temp_files';
+    case Dashboards            = 'opendxp:security:permission:dashboards';
+    case DocumentTypes         = 'opendxp:security:permission:document_types';
+    case Documents             = 'opendxp:security:permission:documents';
+    case Emails                = 'opendxp:security:permission:emails';
+    case NotesEvents           = 'opendxp:security:permission:notes_events';
+    case Objects               = 'opendxp:security:permission:objects';
+    case PredefinedProperties  = 'opendxp:security:permission:predefined_properties';
+    case AssetMetadata         = 'opendxp:security:permission:asset_metadata';
+    case Recyclebin            = 'opendxp:security:permission:recyclebin';
+    case Redirects             = 'opendxp:security:permission:redirects';
+    case Seemode               = 'opendxp:security:permission:seemode';
+    case ShareConfigurations   = 'opendxp:security:permission:share_configurations';
+    case SystemSettings        = 'opendxp:security:permission:system_settings';
+    case TagsConfiguration     = 'opendxp:security:permission:tags_configuration';
+    case TagsAssignment        = 'opendxp:security:permission:tags_assignment';
+    case TagsSearch            = 'opendxp:security:permission:tags_search';
+    case Thumbnails            = 'opendxp:security:permission:thumbnails';
+    case Translations          = 'opendxp:security:permission:translations';
+    case Users                 = 'opendxp:security:permission:users';
+    case WebsiteSettings       = 'opendxp:security:permission:website_settings';
+    case WorkflowDetails       = 'opendxp:security:permission:workflow_details';
+    case Notifications         = 'opendxp:security:permission:notifications';
+    case NotificationsSend     = 'opendxp:security:permission:notifications_send';
+    case Sites                 = 'opendxp:security:permission:sites';
+    case ObjectsSortMethod     = 'opendxp:security:permission:objects_sort_method';
+    case Objectbricks          = 'opendxp:security:permission:objectbricks';
+    case Fieldcollections      = 'opendxp:security:permission:fieldcollections';
+    case QuantityValueUnits    = 'opendxp:security:permission:quantityValueUnits';
+    case Classificationstore   = 'opendxp:security:permission:classificationstore';
+    case MaintenanceMode       = 'opendxp:security:permission:maintenance_mode';
+}

--- a/lib/Security/ElementPermission.php
+++ b/lib/Security/ElementPermission.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (https://pimcore.com)
+ * @copyright  Modification Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Security;
+
+enum ElementPermission: string
+{
+    case List        = 'opendxp:security:element:permission:list';
+    case View        = 'opendxp:security:element:permission:view';
+    case Save        = 'opendxp:security:element:permission:save';
+    case Publish     = 'opendxp:security:element:permission:publish';
+    case Unpublish   = 'opendxp:security:element:permission:unpublish';
+    case Delete      = 'opendxp:security:element:permission:delete';
+    case Rename      = 'opendxp:security:element:permission:rename';
+    case Create      = 'opendxp:security:element:permission:create';
+    case Settings    = 'opendxp:security:element:permission:settings';
+    case Versions    = 'opendxp:security:element:permission:versions';
+    case Properties  = 'opendxp:security:element:permission:properties';
+}

--- a/lib/Security/PermissionAttribute.php
+++ b/lib/Security/PermissionAttribute.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (https://pimcore.com)
+ * @copyright  Modification Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Security;
+
+final class PermissionAttribute
+{
+    public const string PREFIX = 'opendxp:security:permission:';
+
+    public const string ELEMENT_PREFIX = 'opendxp:security:element:permission:';
+
+    public static function for(string $attribute): string
+    {
+        return str_replace([self::PREFIX, self::ELEMENT_PREFIX], '', $attribute);
+    }
+}

--- a/lib/Security/Voter/ElementPermissionVoter.php
+++ b/lib/Security/Voter/ElementPermissionVoter.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (https://pimcore.com)
+ * @copyright  Modification Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Security\Voter;
+
+use OpenDxp\Model\Element\ElementInterface;
+use OpenDxp\Security\PermissionAttribute;
+use OpenDxp\Security\User\TokenStorageUserResolver;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+final class ElementPermissionVoter extends Voter
+{
+    public function __construct(
+        private readonly TokenStorageUserResolver $tokenResolver,
+    ) {
+    }
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return $subject instanceof ElementInterface && str_starts_with($attribute, PermissionAttribute::ELEMENT_PREFIX);
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $this->tokenResolver->getUser();
+
+        return
+            $user !== null &&
+            $subject instanceof ElementInterface &&
+            $subject->isAllowed(PermissionAttribute::for($attribute), $user);
+    }
+}

--- a/lib/Security/Voter/UserPermissionVoter.php
+++ b/lib/Security/Voter/UserPermissionVoter.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (https://pimcore.com)
+ * @copyright  Modification Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Security\Voter;
+
+use OpenDxp\Security\PermissionAttribute;
+use OpenDxp\Security\User\TokenStorageUserResolver;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+final class UserPermissionVoter extends Voter
+{
+    public function __construct(
+        private readonly TokenStorageUserResolver $tokenResolver,
+    ) {
+    }
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return $subject === null && str_starts_with($attribute, PermissionAttribute::PREFIX);
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $this->tokenResolver->getUser();
+
+        return $user !== null && $user->isAllowed(PermissionAttribute::for($attribute));
+    }
+}


### PR DESCRIPTION
# Permission Voters

OpenDXP bridges its own permission checks (`User::isAllowed()` and `ElementInterface::isAllowed()`) into Symfony's authorization layer, so you can use `#[IsGranted]` and `Security::isGranted()`.

## Two voters to rule them all

### UserPermissionVoter
Flat/global permission check, same as `$user->isAllowed($key)`. 
Keys come from `OpenDxp\Security\CorePermission` or any bundle's own permission enum (see below).

### ElementPermissionVoter
Element ACL check, same as `$element->isAllowed($type, $user)`. 
Keys come from `OpenDxp\Security\ElementPermission` (`View`, `Publish`, `Delete`, `Rename`, `Create`, `Settings`, `Versions`, `Properties`, `List`). 

Per-language edit/view permissions and layout restrictions are a separate, non-boolean mechanism and not part of this enum.

***

## Flat permission check

```php
#[IsGranted(CorePermission::Assets->value)]
class MyController extends AdminAbstractController
{
}
```

## Element ACL check

Declarative, with the element resolved from a controller argument:

```php
#[IsGranted(ElementPermission::View->value, subject: 'asset')]
public function myAction(Asset $asset): Response
{
}
```

Imperative:

```php
if ($security->isGranted(ElementPermission::View->value, $element)) {
    // ...
}

$security->denyAccessUnlessGranted(ElementPermission::Publish->value, $element);
```