### PR TITLE
bugfix: make invisible fields in fieldcollections editable

### DIFF
--- a/models/DataObject/ClassDefinition/Data/Fieldcollections.php
+++ b/models/DataObject/ClassDefinition/Data/Fieldcollections.php
@@ -153,7 +153,9 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
 
                 foreach ($collectionDef->getFieldDefinitions() as $fd) {
                     $invisible = $fd->getInvisible();
-                    if ($invisible && !is_null($oIndex)) {
+                    $hasSubmittedValue = array_key_exists($fd->getName(), $collectionRaw['data']);
+
+                    if ($invisible && !$hasSubmittedValue && !is_null($oIndex)) {
                         $containerGetter = 'get' . ucfirst($fieldname);
                         $container = $object->$containerGetter();
                         if ($container) {
@@ -167,7 +169,7 @@ class Fieldcollections extends Data implements CustomResourcePersistingInterface
 
                             $collectionData[$fd->getName()] = $invisibleData;
                         }
-                    } elseif (array_key_exists($fd->getName(), $collectionRaw['data'])) {
+                    } elseif ($hasSubmittedValue) {
                         $collectionParams = [
                             'context' => [
                                 'containerType' => 'fieldcollection',


### PR DESCRIPTION
<!--

Before submitting a contribution, please make sure you’re working on the correct branch:

- Bug fixes → target the latest maintenance branch (`1.0`)
- Features or improvements → target the main development branch (`1.x`)

> Note: All bug fixes merged into maintenance branches are regularly synced into the `1.x` dev branch.

## Your pull request must meet all of the following requirements:

- [x] I have read and accepted the [CLA guidelines](/CLA.md).
- [ ] Features are properly documented in the `doc/` folder.
- [x] Bug fixes include a short guide on how to reproduce the issue.
      → The target branch must be the oldest actively supported version (e.g. `1.0`; see `README.md` for details).
- [ ] Code follows project standards and passes all checks (e.g. PhpStan).

**Pull requests that don't follow these rules may be closed without comment.**

-->

## Changes in this pull request
Changed the branch condition so a submitted value always wins, and the invisible-restore path is only a fallback for genuinely absent data (e.g. a real invisible field with no editor widget at all, where collectionRaw['data'] never contains the key in the first place).

Fieldcollections::getDataFromEditmode() branches on $fd->getInvisible() to decide whether to keep the persisted value or take the submitted one. Custom layouts can expose a raw-invisible field as a normal editable widget (e.g. the "Main (Admin Mode)" layout on an object exposing a hidden field from a fieldcollection), but this method has no way to know that: it only ever sees invisible => true and unconditionally restores the old persisted value, discarding whatever was actually submitted in $collectionRaw['data'].

Block::getDataFromEditmode() avoids this: its restore branch falls back to the persisted value with $blockElement[$elementName] ?? $item->getData(), so a submitted value always wins and the persisted value is used only when nothing was submitted at all.

This PR applies the same precedence to Fieldcollections: it now checks whether the field's key is present in the submitted data first, and only falls into the invisible-restore branch when it's genuinely absent (the true invisible-field-with-no-widget case, which still needs its value carried forward since the whole item is rebuilt from scratch on every save).

Resolves #
A bug where a field in a fieldcollection is marked noteditable => true and invisible => true in the raw class definition. The classes additionally have the ("Main (Admin Mode)") layout that exposes this field as normal and editable.

## Additional info