### PR TITLE
fix: restore ReverseObjectRelation ownerClassId on definition import

### DIFF
--- a/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
+++ b/models/DataObject/ClassDefinition/Data/ReverseObjectRelation.php
@@ -60,6 +60,16 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
     /**
      * @return $this
      */
+    public function setOwnerClassId(string $ownerClassId): static
+    {
+        $this->ownerClassId = $ownerClassId;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
     public function setOwnerClassName(string $ownerClassName): static
     {
         $this->ownerClassName = $ownerClassName;
@@ -214,6 +224,12 @@ class ReverseObjectRelation extends ManyToManyObjectRelation
     #[Override]
     public function getClasses(): array
     {
+        // Prefer ownerClassName from definition export; avoid DB lookup via getOwnerClassId()
+        // so DB-less class builds keep concrete reverse-relation phpdocs.
+        if (!empty($this->ownerClassName)) {
+            return Model\Element\Service::fixAllowedTypes([$this->ownerClassName], 'classes');
+        }
+
         if ($this->getOwnerClassId()) {
             return Model\Element\Service::fixAllowedTypes([$this->ownerClassName], 'classes');
         }


### PR DESCRIPTION
## Changes in this pull request
When class definitions are imported/built without a database (e.g. CI `build:classes`), `ReverseObjectRelation` currently fails to keep concrete relation phpdocs because:

1. There is no `setOwnerClassId()` setter, so `ownerClassId` from the exported definition is not restored on import.
2. `getClasses()` always goes through `getOwnerClassId()`, which may trigger a DB lookup via `ClassDefinition::getByName()`.

This PR adds `setOwnerClassId()` and prefers the already exported `ownerClassName` in `getClasses()` before falling back to the ID-based path.

Resolves # <!-- add issue if created -->

## How to reproduce
1. Export a class definition that contains a `reverseObjectRelation` with `ownerClassId` / `ownerClassName`.
2. Run a DB-less class build / definition import (no live class table).
3. Observe that reverse-relation phpdocs stay generic / owner metadata is incomplete.

## Additional info
- Same fix is already used as a Composer patch on a Pimcore 11 project; opening it upstream for OpenDXP so the patch can be dropped later.
- Target branch: `1.x` (only active remote line; no `1.0` branch present).
- CLA: will be accepted with this contribution.