### PR TITLE
Fix application log archive growing with duplicate rows

### DIFF
--- a/bundles/ApplicationLoggerBundle/src/Installer.php
+++ b/bundles/ApplicationLoggerBundle/src/Installer.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 
 namespace OpenDxp\Bundle\ApplicationLoggerBundle;
 
+use OpenDxp\Bundle\ApplicationLoggerBundle\Handler\ApplicationLoggerDb;
+use OpenDxp\Bundle\ApplicationLoggerBundle\Schema\ApplicationLogSchema;
 use OpenDxp\Bundle\ApplicationLoggerBundle\Security\ApplicationLoggerPermission;
 use OpenDxp\Extension\Bundle\Installer\SettingsStoreAwareInstaller;
 use OpenDxp\Security\PermissionAttribute;
@@ -47,26 +49,9 @@ class Installer extends SettingsStoreAwareInstaller
     {
         $db = \OpenDxp\Db::get();
 
-        $db->executeQuery("CREATE TABLE IF NOT EXISTS `application_logs` (
-          `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-          `pid` INT(11) NULL DEFAULT NULL,
-          `timestamp` datetime NOT NULL,
-          `message` TEXT NULL,
-          `priority` ENUM('emergency','alert','critical','error','warning','notice','info','debug') DEFAULT NULL,
-          `fileobject` varchar(1024) DEFAULT NULL,
-          `info` varchar(1024) DEFAULT NULL,
-          `component` varchar(190) DEFAULT NULL,
-          `source` varchar(190) DEFAULT NULL,
-          `relatedobject` int(11) unsigned DEFAULT NULL,
-          `relatedobjecttype` enum('object','document','asset') DEFAULT NULL,
-          `maintenanceChecked` tinyint(1) DEFAULT NULL,
-          PRIMARY KEY (`id`),
-          KEY `component` (`component`),
-          KEY `timestamp` (`timestamp`),
-          KEY `relatedobject` (`relatedobject`),
-          KEY `priority` (`priority`),
-          KEY `maintenanceChecked` (`maintenanceChecked`)
-        ) DEFAULT CHARSET=utf8mb4;");
+        $db->executeQuery(ApplicationLogSchema::createLogTable(
+            $db->quoteIdentifier(ApplicationLoggerDb::TABLE_NAME)
+        ));
     }
 
     private function dropApplicationLogTable(): void

--- a/bundles/ApplicationLoggerBundle/src/Maintenance/LogArchiveTask.php
+++ b/bundles/ApplicationLoggerBundle/src/Maintenance/LogArchiveTask.php
@@ -136,8 +136,7 @@ class LogArchiveTask implements TaskInterface
 
         $this->db->executeStatement(
             sprintf(
-                'INSERT INTO %1$s SELECT * FROM %2$s WHERE %2$s.id IN (?)
-                    ON DUPLICATE KEY UPDATE %1$s.`id` = %1$s.`id`',
+                'INSERT IGNORE INTO %s SELECT * FROM %s WHERE id IN (?)',
                 $archiveTable,
                 $sourceTable
             ),

--- a/bundles/ApplicationLoggerBundle/src/Maintenance/LogArchiveTask.php
+++ b/bundles/ApplicationLoggerBundle/src/Maintenance/LogArchiveTask.php
@@ -20,8 +20,11 @@ use Carbon\Carbon;
 use DateInterval;
 use DateTime;
 use DateTimeImmutable;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
+use League\Flysystem\FilesystemOperator;
 use OpenDxp\Bundle\ApplicationLoggerBundle\Handler\ApplicationLoggerDb;
+use OpenDxp\Bundle\ApplicationLoggerBundle\Schema\ApplicationLogSchema;
 use OpenDxp\Config;
 use OpenDxp\DateFormat;
 use OpenDxp\Maintenance\TaskInterface;
@@ -33,6 +36,8 @@ use Psr\Log\LoggerInterface;
  */
 class LogArchiveTask implements TaskInterface
 {
+    private const int BATCH_SIZE = 1000;
+
     public function __construct(
         private readonly Connection $db,
         private Config $config,
@@ -66,50 +71,25 @@ class LogArchiveTask implements TaskInterface
         );
 
         if ($count > 0) {
-            $this->db->executeStatement(sprintf(
-                "CREATE TABLE IF NOT EXISTS %s (
-                    id BIGINT(20) NOT NULL,
-                    `pid` INT(11) NULL DEFAULT NULL,
-                    `timestamp` DATETIME NOT NULL,
-                    message VARCHAR(1024),
-                    `priority` ENUM('emergency','alert','critical','error','warning','notice','info','debug') DEFAULT NULL,
-                    fileobject VARCHAR(1024),
-                    info VARCHAR(1024),
-                    component VARCHAR(255),
-                    source VARCHAR(255) NULL DEFAULT NULL,
-                    relatedobject BIGINT(20),
-                    relatedobjecttype ENUM('object', 'document', 'asset'),
-                    maintenanceChecked TINYINT(1)
-                ) ENGINE = ARCHIVE ROW_FORMAT = DEFAULT",
-                $archiveTable
-            ));
-
-            $this->db->executeStatement(
-                sprintf('INSERT INTO %s SELECT * FROM %s WHERE `timestamp` < ?', $archiveTable, $sourceTable),
-                $whereParams
-            );
+            $this->db->executeStatement(ApplicationLogSchema::createArchiveTable($archiveTable));
 
             $this->logger->debug(sprintf(
                 'Deleting referenced FileObjects of application_logs which are older than %d days',
                 $archiveThreshold
             ));
 
-            $fileObjectPaths = $this->db->fetchAllAssociative(
-                sprintf('SELECT fileobject FROM %s WHERE `timestamp` < ?', $sourceTable),
-                $whereParams
-            );
+            do {
+                $rows = $this->db->fetchAllAssociative(
+                    sprintf(
+                        'SELECT id, fileobject FROM %s WHERE `timestamp` < ? ORDER BY id LIMIT %d',
+                        $sourceTable,
+                        self::BATCH_SIZE
+                    ),
+                    $whereParams
+                );
 
-            foreach ($fileObjectPaths as $objectPath) {
-                $filePath = $objectPath['fileobject'];
-                if ($filePath !== null && $storage->fileExists($filePath)) {
-                    $storage->delete($filePath);
-                }
-            }
-
-            $this->db->executeStatement(
-                sprintf('DELETE FROM %s WHERE `timestamp` < ?', $sourceTable),
-                $whereParams
-            );
+                $this->archiveBatch($archiveTable, $sourceTable, $rows, $storage);
+            } while (count($rows) === self::BATCH_SIZE);
         }
 
         $archiveTables = $this->db->fetchFirstColumn(
@@ -138,6 +118,43 @@ class LogArchiveTask implements TaskInterface
                         $storage->deleteDirectory($folderName);
                     }
                 }
+            }
+        }
+    }
+
+    private function archiveBatch(
+        string $archiveTable,
+        string $sourceTable,
+        array $rows,
+        FilesystemOperator $storage
+    ): void {
+        if ($rows === []) {
+            return;
+        }
+
+        $ids = array_map(intval(...), array_column($rows, 'id'));
+
+        $this->db->executeStatement(
+            sprintf(
+                'INSERT INTO %1$s SELECT * FROM %2$s WHERE %2$s.id IN (?)
+                    ON DUPLICATE KEY UPDATE %1$s.`id` = %1$s.`id`',
+                $archiveTable,
+                $sourceTable
+            ),
+            [$ids],
+            [ArrayParameterType::INTEGER]
+        );
+
+        $this->db->executeStatement(
+            sprintf('DELETE FROM %s WHERE id IN (?)', $sourceTable),
+            [$ids],
+            [ArrayParameterType::INTEGER]
+        );
+
+        foreach ($rows as $row) {
+            $filePath = $row['fileobject'];
+            if ($filePath !== null && $storage->fileExists($filePath)) {
+                $storage->delete($filePath);
             }
         }
     }

--- a/bundles/ApplicationLoggerBundle/src/Schema/ApplicationLogSchema.php
+++ b/bundles/ApplicationLoggerBundle/src/Schema/ApplicationLogSchema.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Bundle\ApplicationLoggerBundle\Schema;
+
+/**
+ * @internal
+ */
+final class ApplicationLogSchema
+{
+    private const string COLUMNS = <<<'SQL'
+        `pid` int(11) NULL DEFAULT NULL,
+        `timestamp` datetime NOT NULL,
+        `message` text NULL,
+        `priority` enum('emergency','alert','critical','error','warning','notice','info','debug') DEFAULT NULL,
+        `fileobject` varchar(1024) DEFAULT NULL,
+        `info` varchar(1024) DEFAULT NULL,
+        `component` varchar(190) DEFAULT NULL,
+        `source` varchar(190) DEFAULT NULL,
+        `relatedobject` int(11) unsigned DEFAULT NULL,
+        `relatedobjecttype` enum('object','document','asset') DEFAULT NULL,
+        `maintenanceChecked` tinyint(1) DEFAULT NULL
+        SQL;
+
+    public static function createLogTable(string $table): string
+    {
+        return sprintf(
+            'CREATE TABLE IF NOT EXISTS %s (
+                `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+                %s,
+                PRIMARY KEY (`id`),
+                KEY `component` (`component`),
+                KEY `timestamp` (`timestamp`),
+                KEY `relatedobject` (`relatedobject`),
+                KEY `priority` (`priority`),
+                KEY `maintenanceChecked` (`maintenanceChecked`)
+            ) DEFAULT CHARSET=utf8mb4',
+            $table,
+            self::COLUMNS
+        );
+    }
+
+    public static function createArchiveTable(string $table): string
+    {
+        return sprintf(
+            'CREATE TABLE IF NOT EXISTS %s (
+                `id` bigint(20) unsigned NOT NULL,
+                %s,
+                PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
+            $table,
+            self::COLUMNS
+        );
+    }
+}

--- a/bundles/ApplicationLoggerBundle/src/Schema/ApplicationLogSchema.php
+++ b/bundles/ApplicationLoggerBundle/src/Schema/ApplicationLogSchema.php
@@ -56,10 +56,10 @@ final class ApplicationLogSchema
     {
         return sprintf(
             'CREATE TABLE IF NOT EXISTS %s (
-                `id` bigint(20) unsigned NOT NULL,
+                `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
                 %s,
                 PRIMARY KEY (`id`)
-            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
+            ) ENGINE=ARCHIVE DEFAULT CHARSET=utf8mb4',
             $table,
             self::COLUMNS
         );

--- a/bundles/ApplicationLoggerBundle/src/Schema/ApplicationLogSchema.php
+++ b/bundles/ApplicationLoggerBundle/src/Schema/ApplicationLogSchema.php
@@ -21,6 +21,7 @@ namespace OpenDxp\Bundle\ApplicationLoggerBundle\Schema;
 final class ApplicationLogSchema
 {
     private const string COLUMNS = <<<'SQL'
+        `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
         `pid` int(11) NULL DEFAULT NULL,
         `timestamp` datetime NOT NULL,
         `message` text NULL,
@@ -38,7 +39,6 @@ final class ApplicationLogSchema
     {
         return sprintf(
             'CREATE TABLE IF NOT EXISTS %s (
-                `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
                 %s,
                 PRIMARY KEY (`id`),
                 KEY `component` (`component`),
@@ -56,7 +56,6 @@ final class ApplicationLogSchema
     {
         return sprintf(
             'CREATE TABLE IF NOT EXISTS %s (
-                `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
                 %s,
                 PRIMARY KEY (`id`)
             ) ENGINE=ARCHIVE DEFAULT CHARSET=utf8mb4',

--- a/bundles/CoreBundle/src/Migrations/Version20260903064009.php
+++ b/bundles/CoreBundle/src/Migrations/Version20260903064009.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use OpenDxp\Bundle\ApplicationLoggerBundle\Handler\ApplicationLoggerDb;
+use OpenDxp\Config;
+
+final class Version20260903064009 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $config = Config::getSystemConfiguration('applicationlog') ?? [];
+        $database = ($config['archive_alternative_database'] ?? null) ?: $this->connection->getDatabase();
+
+        $tables = $this->connection->fetchFirstColumn(
+            'SELECT table_name
+                FROM information_schema.columns
+                WHERE table_schema = ?
+                  AND table_name LIKE ?
+                  AND column_name = ?
+                  AND data_type = ?',
+            [$database, ApplicationLoggerDb::TABLE_ARCHIVE_PREFIX . '_%', 'message', 'varchar']
+        );
+
+        foreach ($tables as $table) {
+            $this->addSql(sprintf(
+                'ALTER TABLE %s.%s
+                    MODIFY `id` bigint(20) unsigned NOT NULL,
+                    MODIFY `message` text NULL,
+                    MODIFY `relatedobject` int(11) unsigned DEFAULT NULL',
+                $this->connection->quoteIdentifier($database),
+                $this->connection->quoteIdentifier($table)
+            ));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        // do nothing
+    }
+}


### PR DESCRIPTION
Archiving now runs in batches of 1000 rows. Each batch inserts, then deletes exactly those ids. The archive tables got a primary key on id, so a run that dies in between can just be repeated.

The tables stay on `ENGINE=ARCHIVE`. It does allow a primary key, but only on an `AUTO_INCREMENT` column, which is why `id` is declared that way.

The archive DDL was also wrong for about seven years. `message` was widened to `TEXT` in `application_logs` (upstream#1354) but stayed `VARCHAR(1024)` in the archive, so long messages were cut off while being archived. Both tables kept their own copy of the column list. This has been moved to a single source of truth. The included migration fixes existing archive tables.

> [!NOTE]
> The archive table of the current month keeps its existing form, so duplicates are only fully ruled out from next month's table on. That is not a problem. Each batch is now deleted from application_logs right after it was archived, so a run that dies keeps the work it already did.  

Fixes #180