### PR TITLE
remove Finder sorting from version migration command example

### DIFF
--- a/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/Version_Migration.md
+++ b/doc/23_Installation_and_Upgrade/09_Upgrade_Notes/Version_Migration.md
@@ -60,7 +60,7 @@ class MigrateVersionFilesCommand extends Command
         $io->text(sprintf('Searching: %s', $basePath));
 
         $finder = new Finder();
-        $finder->files()->in($basePath)->sortByName();
+        $finder->files()->in($basePath);
 
         $totalFiles = 0;
         $migratedFiles = 0;


### PR DESCRIPTION
`sortByName()` forces the Finder to load every `SplFileInfo` into an array before the first file is yielded. On instances with tens of thousands of version files this exhausts the memory limit. 